### PR TITLE
Fix sliceIndex implementation for Slice (Any sh)

### DIFF
--- a/Data/Array/Accelerate/Array/Representation.hs
+++ b/Data/Array/Accelerate/Array/Representation.hs
@@ -28,7 +28,7 @@ import Data.Array.Accelerate.Type
 
 -- |Class of index representations (which are nested pairs)
 --
-class Eq sh => Shape sh where
+class (Eq sh, Slice sh) => Shape sh where
   -- user-facing methods
   dim       :: sh -> Int             -- ^number of dimensions (>= 0); rank of the array
   size      :: sh -> Int             -- ^total number of elements in an array of this /shape/

--- a/accelerate-examples/tests/simple/SliceExamples.hs
+++ b/accelerate-examples/tests/simple/SliceExamples.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE TypeOperators, ScopedTypeVariables #-}
+module SliceExamples where
+
+import Data.Array.Accelerate as Acc
+import Data.Array.Accelerate.Interpreter
+
+--    y
+--    ^
+--    |  3   4 
+--    |  1   2
+--     -------> x
+--
+arr :: Acc (Array DIM2 Int)
+arr = use $ fromList (Z:.2:.2) [1,2,3,4]
+
+slice1 :: Exp (Z:.Int:.All:.All)
+slice1 = lift $ Z:.(2::Int):.All:.All
+
+slice2 :: Exp (Z:.All:.Int:.All)
+slice2 = lift $ Z:.All:.(2::Int):.All
+
+slice3 :: Exp (Z:.All:.All:.Int)
+slice3 = lift $ Z:.All:.All:.(2::Int)
+
+-- Replicate into z-axis
+-- should produce [1,2,3,4,1,2,3,4]
+test1 :: Array DIM3 Int
+test1 = run $ Acc.replicate slice1 arr
+
+-- Replicate into y-axis
+-- should produce [1,2,1,2,3,4,3,4]
+test2 :: Array DIM3 Int
+test2 = run $ Acc.replicate slice2 arr
+
+-- Replicate into x-axis
+-- should produce [1,1,2,2,3,3,4,4]
+test3 :: Array DIM3 Int
+test3 = run $ Acc.replicate slice3 arr
+
+--
+-- repN. Replicates an array into the rightmost dimension of
+-- the result array.
+--
+repN :: forall sh e. (Shape sh, Elt e)
+     => Int 
+     -> Acc (Array sh e)
+     -> Acc (Array (sh:.Int) e)
+repN n a = Acc.replicate (lift (Any:.n :: Any sh:.Int)) a
+
+rep1 :: Acc (Array DIM0 Int) -> Acc (Array DIM1 Int)
+rep1 = repN 2
+
+rep2 :: Acc (Array DIM2 Int) -> Acc (Array DIM3 Int)
+rep2 = repN 2
+
+rep2' :: Acc (Array DIM2 Int) -> Acc (Array DIM3 Int)
+rep2' = Acc.replicate (lift (Z:.All:.All:.(2::Int)))
+
+slice1' :: Any (Z:.Int:.Int) :. Int
+slice1' = Any:.2
+
+slice2' :: Z:.All:.All:.Int
+slice2' = Z:.All:.All:.2


### PR DESCRIPTION
The implementation of convertSliceIndex uses unsafeCoerce.
While testing the use of the repN function (defined in
SliceExamples.hs) I found a case where the type equality didn't
hold.

   Repr.SliceShape (EltRepr (Any sh))
:: Repr.SliceShape ()
:: ()

but

   EltRepr (SliceShape (Any sh))
:: EltRepr sh

These are clearly not the same in general.

I created a new class ShapeElt which represents the types
of values that can be shapes (not slice specifiers). I added
two new type families. The first,'SliceAnyRepr' maps from types, 'sh',
satisfying 'ShapeElt' to the representation of the slice
'Any sh'.

e.g. Any (Z:.Int) is effectively the same as Z:.All which
is represented by ((),()) (in module D.A.A.Array.Representation)
Therefore 'SliceAnyRepr (Z:.Int) :: ((),())'

The other type family is ShapeEltRepr which was added
for future purposes because I've got an idea about how to
remove the need for 'convertSliceIndex' and place
more restrictions on what can be shapes and slices in
constructors such as Replicate.

With this fix function 'repN' now produces correct results.
