### PR TITLE
Sharing recovery fix

### DIFF
--- a/Data/Array/Accelerate/Debug.hs
+++ b/Data/Array/Accelerate/Debug.hs
@@ -15,7 +15,7 @@
 module Data.Array.Accelerate.Debug (
 
   -- * Conditional tracing
-  initTrace, queryTrace, traceLine, traceChunk
+  initTrace, queryTrace, traceLine, traceChunk, trace
 
 ) where
 
@@ -24,6 +24,7 @@ import Control.Monad
 import Data.IORef
 import System.IO
 import System.IO.Unsafe (unsafePerformIO)
+import qualified Debug.Trace as Trace
 
 -- friends
 import Data.Array.Accelerate.Pretty ()
@@ -66,3 +67,11 @@ traceChunk header msg
        ; when doTrace 
          $ hPutStrLn stderr (header ++ "\n  " ++ msg)
        }
+
+-- | Like Debug.Trace but only when the /trace flag/ is set.
+trace :: String -> a -> a
+trace msg v = unsafePerformIO $ do
+  doTrace <- queryTrace
+  if doTrace
+    then return $ Trace.trace msg v
+    else return v

--- a/accelerate-examples/src/Main.hs
+++ b/accelerate-examples/src/Main.hs
@@ -72,4 +72,3 @@ main = do
   valid           <- runVerify config tests
   --
   unless (null valid || cfgVerify config) $ runTiming config valid
-

--- a/accelerate-examples/src/Test.hs
+++ b/accelerate-examples/src/Test.hs
@@ -28,6 +28,7 @@ import qualified BlockCopy
 
 import qualified Canny
 import qualified IntegralImage
+import qualified SharingRecovery
 
 -- friends
 import Util
@@ -108,6 +109,7 @@ data Test
 allTests :: Config -> IO [Test]
 allTests cfg = sequence'
   [
+
     -- primitive functions
     mkTest "map-abs"         "absolute value of each element"             $ Map.run "abs" n
   , mkTest "map-plus"        "add a constant to each element"             $ Map.run "plus" n
@@ -144,7 +146,16 @@ allTests cfg = sequence'
   , mkTest "slices"  "replicate (Z:.All:.All:.2)" $ SliceExamples.run3
   , mkTest "slices"  "replicate (Any:.2)"         $ SliceExamples.run4  
   , mkTest "slices"  "replicate (Z:.2:.2:.2)"     $ SliceExamples.run5
-    
+  --
+  , mkIO "sharing-recovery" "simple"    $ return (show SharingRecovery.simple)
+  , mkIO "sharing-recovery" "orderFail" $ return (show SharingRecovery.orderFail)
+  , mkIO "sharing-recovery" "testSort"  $ return (show SharingRecovery.testSort)
+  , mkIO "sharing-recovery" "muchSharing" $ return (show $ SharingRecovery.muchSharing 20)
+  , mkIO "sharing-recovery" "bfsFail"   $ return (show SharingRecovery.bfsFail)
+  , mkIO "sharing-recovery" "twoLetsSameLevel"  $ return (show SharingRecovery.twoLetsSameLevel)
+  , mkIO "sharing-recovery" "twoLetsSameLevel2" $ return (show SharingRecovery.twoLetsSameLevel2)
+  , mkIO "sharing-recovery" "noLetAtTop"   $ return (show SharingRecovery.noLetAtTop)
+  , mkIO "sharing-recovery" "noLetAtTop2"   $ return (show SharingRecovery.noLetAtTop2)
   ]
   where
     n   = cfgElements cfg
@@ -158,9 +169,8 @@ allTests cfg = sequence'
       acc <- unsafeInterleaveIO builder
       return $ TestNoRef name desc acc
 
-#ifdef ACCELERATE_IO
     mkIO name desc act = return $ TestIO name desc act
-#endif
+
 
 -- How to evaluate Accelerate programs with the chosen backend?
 --
@@ -193,7 +203,7 @@ verifyTest cfg test = do
                                     $ map (\(i,v) -> ">>> " ++ shows i " : " ++ show v) errs
 
         TestNoRef _ _ acc -> return $ run acc `seq` Ok
-        TestIO _ _ act    -> act >> return Ok
+        TestIO _ _ act    -> act >>= \v -> v `seq` return Ok
       --
       unless quiet $ putStrLn (show result)
       return result

--- a/accelerate-examples/tests/simple/SharingRecovery.hs
+++ b/accelerate-examples/tests/simple/SharingRecovery.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE TypeOperators, ScopedTypeVariables #-}
+
+
+--
+-- Some tests to make sure that sharing recovery is working.
+--
+module SharingRecovery where
+
+import Prelude hiding (zip3)
+
+import Data.Array.Accelerate as Acc
+
+
+mkArray :: Int -> Acc (Array DIM1 Int)
+mkArray n = use $ fromList (Z:.1) [n]
+
+muchSharing :: Int -> Acc (Array DIM1 Int)
+muchSharing 0 = (mkArray 0)
+muchSharing n = Acc.map (\_ -> newArr ! (lift (Z:.(0::Int))) +
+                               newArr ! (lift (Z:.(1::Int)))) (mkArray n)
+  where
+    newArr = muchSharing (n-1)
+
+idx :: Int -> Exp DIM1
+idx i = lift (Z:.i)
+
+bfsFail :: Acc (Array DIM1 Int)
+bfsFail = Acc.map (\x -> (map2 ! (idx 1)) +  (map1 ! (idx 2)) + x) arr
+  where
+    map1 :: Acc (Array DIM1 Int)
+    map1 =  Acc.map (\y -> (map2 ! (idx 3)) + y) arr
+    map2 :: Acc (Array DIM1 Int)
+    map2 =  Acc.map (\z -> z + 1) arr
+    arr  :: Acc (Array DIM1 Int)
+    arr =  mkArray 666
+
+twoLetsSameLevel :: Acc (Array DIM1 Int)
+twoLetsSameLevel =
+  let arr1 = mkArray 1
+  in let arr2 = mkArray 2
+     in  Acc.map (\_ -> arr1!(idx 1) + arr1!(idx 2) + arr2!(idx 3) + arr2!(idx 4)) (mkArray 3)
+
+twoLetsSameLevel2 :: Acc (Array DIM1 Int)
+twoLetsSameLevel2 =
+ let arr2 = mkArray 2
+ in let arr1 = mkArray 1
+    in  Acc.map (\_ -> arr1!(idx 1) + arr1!(idx 2) + arr2!(idx 3) + arr2!(idx 4)) (mkArray 3)
+
+--
+-- These two programs test that lets can be introduced not just at the top of a AST
+-- but in intermediate nodes.
+--
+noLetAtTop :: Acc (Array DIM1 Int)
+noLetAtTop = Acc.map (\x -> x + 1) bfsFail
+
+noLetAtTop2 :: Acc (Array DIM1 Int)
+noLetAtTop2 = Acc.map (\x -> x + 2) $ Acc.map (\x -> x + 1) bfsFail
+
+--
+--
+--
+simple :: Acc (Array DIM1 (Int,Int))
+simple = Acc.map (\_ -> a ! (idx 1))  d
+  where
+    c = use $ Acc.fromList (Z :. 3) [1..]
+    d = Acc.map (+1) c
+    a = Acc.zip d c
+
+--------------------------------------------------------------------------------
+--
+-- sortKey is a real program that Ben Lever wrote. It has some pretty interesting
+-- sharing going on.
+--
+sortKey :: (Elt e)
+        => (Exp e -> Exp Int)         -- ^mapping function to produce key array from input array
+        -> Acc (Vector e)
+        -> Acc (Vector e)
+sortKey keyFun arr =  foldl sortOneBit arr (Prelude.map lift ([0..31] :: [Int]))
+  where
+    sortOneBit inArr bitNum = outArr
+      where
+        keys    = Acc.map keyFun inArr
+
+        bits    = Acc.map (\a -> (Acc.testBit a bitNum) ? (1, 0)) keys
+        bitsInv = Acc.map (\b -> (b ==* 0) ? (1, 0)) bits
+
+        (falses, numZeroes) = Acc.scanl' (+) 0 bitsInv
+        trues               = Acc.map (\x -> (Acc.the numZeroes) + (Acc.fst x) - (Acc.snd x)) $
+                               Acc.zip ixs falses
+
+        dstIxs = Acc.map (\x -> let (b, t, f) = unlift x  in (b ==* (constant (0::Int))) ? (f, t)) $
+                   zip3 bits trues falses
+        outArr = scatter dstIxs inArr inArr -- just use input as default array
+                                            --(we're writing over everything anyway)
+    --
+    ixs   = enumeratedArray (shape arr)
+
+-- | Copy elements from source array to destination array according to a map. For
+--   example:
+--
+--    default = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+--    map     = [1, 3, 7, 2, 5, 8]
+--    input   = [1, 9, 6, 4, 4, 2, 5]
+--
+--    output  = [0, 1, 4, 9, 0, 4, 0, 6, 2]
+--
+--   Note if the same index appears in the map more than once, the result is
+--   undefined. The map vector cannot be larger than the input vector.
+--
+scatter :: (Elt e)
+        => Acc (Vector Int)      -- ^map
+        -> Acc (Vector e)        -- ^default
+        -> Acc (Vector e)        -- ^input
+        -> Acc (Vector e)        -- ^output
+scatter mapV defaultV inputV = Acc.permute (const) defaultV pF inputV
+  where
+    pF ix = lift (Z :. (mapV ! ix))
+
+
+-- | Create an array where each element is the value of its corresponding row-major
+--   index.
+--
+--enumeratedArray :: (Shape sh) => Exp sh -> Acc (Array sh Int)
+--enumeratedArray sh = Acc.reshape sh
+--                   $ Acc.generate (index1 $ shapeSize sh) unindex1
+
+enumeratedArray :: Exp DIM1 -> Acc (Array DIM1 Int)
+enumeratedArray sh = Acc.generate sh unindex1
+
+zip3 :: forall sh e1 e2 e3. (Shape sh, Elt e1, Elt e2, Elt e3)
+     => Acc (Array sh e1)
+     -> Acc (Array sh e2)
+     -> Acc (Array sh e3)
+     -> Acc (Array sh (e1, e2, e3))
+zip3 as bs cs = Acc.zipWith (\a bc -> let (b, c) = unlift bc :: (Exp e2, Exp e3)
+                                      in lift (a, b, c)) as $ Acc.zip bs cs
+
+unzip3 :: forall sh. forall e1. forall e2. forall e3. (Shape sh, Elt e1, Elt e2, Elt e3)
+       => Acc (Array sh (e1, e2, e3))
+       -> (Acc (Array sh e1), Acc (Array sh e2), Acc (Array sh e3))
+unzip3 abcs = (as, bs, cs)
+  where
+    (bs, cs)  = Acc.unzip bcs
+    (as, bcs) = Acc.unzip
+              $ Acc.map (\abc -> let (a, b, c) = unlift abc :: (Exp e1, Exp e2, Exp e3)
+                                 in lift (a, lift (b, c))) abcs
+
+testSort = sortKey id $ use $ fromList (Z:.10) [9,8,7,6,5,4,3,2,1,0]
+
+----------------------------------------------------------------------
+
+--
+-- map1 has children map3 and map2.
+-- map2 has child map3.
+-- Back when we still used a list for the NodeCounts data structure this mean that
+-- you would be merging [1,3,2] with [2,3] which violated precondition of (+++).
+-- This tests that the new algorithm works just fine on this.
+--
+orderFail :: Acc (Array DIM1 Int)
+orderFail = Acc.map (\_ -> map1 ! (idx 1) + map2 ! (idx 1)) arr
+  where
+    map1 = Acc.map (\_ -> map3 ! (idx 1) + map2 ! (idx 2)) arr
+    map2 = Acc.map (\_ -> map3 ! (idx 3)) arr
+    map3 = Acc.map (+1) arr
+    arr = mkArray 42

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -120,7 +120,9 @@ Library
                         directory       >= 1.0 && < 1.2,
                         ghc-prim        == 0.2.*,
                         mtl             == 2.0.*,
-                        pretty          == 1.0.*
+                        pretty          == 1.0.*,
+                        hashable        >= 1.1.1.0,
+                        unordered-containers >= 0.1.3.0
 
   Include-Dirs:         include
 


### PR DESCRIPTION
The NodeCounts data structure has changed substantially. It is no longer a list of
node/count pairs with the invariant that all child nodes appear after parent nodes.  It is
now a list of "dependency groups" each dependency group is a directed acyclic graph (DAG)
that captures the dependencies that an AccSharing node can have on VarSharing nodes.

The function 'filterCompleted' now checks and filters out nodes on a per-dependency group
basis.

This commit also introduces a new trace function in D.A.A.Debug and adds tests for sharing
recovery.

There are also some new dependencies added to accelerate.cabal because we are using
unordered containers.
