### PR TITLE
restrict the import of MArray to GHC versions between 7.0 and 7.2.*

### DIFF
--- a/Data/Array/Accelerate/Array/Data.hs
+++ b/Data/Array/Accelerate/Array/Data.hs
@@ -38,7 +38,7 @@ import Control.Monad
 import Control.Monad.ST
 import qualified Data.Array.IArray  as IArray
 import qualified Data.Array.MArray  as MArray hiding (newArray)
-#if __GLASGOW_HASKELL__ == 700
+#if __GLASGOW_HASKELL__ >= 700 && __GLASGOW_HASKELL__ < 703
 import qualified Data.Array.MArray  as Unsafe
 #else
 import qualified Data.Array.Unsafe  as Unsafe


### PR DESCRIPTION
...it's deprecated in 7.3 and above. Now builds without complaints on (at least) 7.0.4, 7.2.1, 7.2.2, 7.4.1-rc2
