### PR TITLE
Fixed implementation of scanr

### DIFF
--- a/Data/Array/Accelerate/Interpreter.hs
+++ b/Data/Array/Accelerate/Interpreter.hs
@@ -431,7 +431,7 @@ scanrOp f e (DelayedArray sh rf)
       | i == 0    = return v
       | otherwise = do
                       writeArrayData arr i v
-                      traverse arr (i - 1) (f' v (rf ((), i)))
+                      traverse arr (i - 1) (f' v (rf ((), i-1)))
 
 scanr'Op :: forall e. (e -> e -> e)
          -> e


### PR DESCRIPTION
Any call to scanr threw an index out of bounds error.

First index value in iteration is i = n, which is correct as
the new array contains n+1 elements.
However, for the old array (which has n elements), the index must be i-1,
not i.
