### PR TITLE
hashable version

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -94,7 +94,7 @@ Library
                         base            == 4.*,
                         containers      >= 0.3,
                         ghc-prim        >= 0.2,
-                        hashable        >= 1.1,
+                        hashable        >= 1.1 && < 1.2,
                         hashtables      >= 1.0,
                         pretty          >= 1.0
 


### PR DESCRIPTION
The API of `hashable` changed with the release of 1.2; this forces the old API for the time being.
