### PR TITLE
Unbreak accelerate for clang

### DIFF
--- a/Data/Array/Accelerate/Array/Sugar.hs
+++ b/Data/Array/Accelerate/Array/Sugar.hs
@@ -663,9 +663,7 @@ sinkFromElt2 f = \x y -> fromElt $ f (toElt x) (toElt y)
 {-# RULES
 
 "fromElt/toElt" forall e.
-  fromElt (toElt e) = e
-
-  #-}
+  fromElt (toElt e) = e #-}
 
 
 -- Foreign functions


### PR DESCRIPTION
http://ghc.haskell.org/trac/ghc/ticket/7678 tracks a similar bug with clang. The error message is:

```
Data/Array/Accelerate/Array/Sugar.hs:668:4:
     error: invalid preprocessing directive
      #-}
       ^
```
