### PR TITLE
Fix Accelerate for ARM

### DIFF
--- a/Data/Array/Accelerate/Array/Data.hs
+++ b/Data/Array/Accelerate/Array/Data.hs
@@ -83,6 +83,11 @@ $( runQ [d| type HTYPE_WORD = $(
                 64 -> [t| Word64 |]
                 _  -> error "I don't know what architecture I am" ) |] )
 
+$( runQ [d| type HTYPE_CHAR = $(
+              case isSigned (undefined::CChar) of
+                True  -> [t| Int8  |]
+                False -> [t| Word8 |] ) |] )
+
 $( runQ [d| type HTYPE_LONG = $(
               case finiteBitSize (undefined::CLong) of
                 32 -> [t| Int32 |]
@@ -136,7 +141,7 @@ data instance GArrayData ba CFloat  = AD_CFloat  (ba Float)
 data instance GArrayData ba CDouble = AD_CDouble (ba Double)
 data instance GArrayData ba Bool    = AD_Bool    (ba Word8)
 data instance GArrayData ba Char    = AD_Char    (ba Char)
-data instance GArrayData ba CChar   = AD_CChar   (ba Int8)
+data instance GArrayData ba CChar   = AD_CChar   (ba HTYPE_CHAR)
 data instance GArrayData ba CSChar  = AD_CSChar  (ba Int8)
 data instance GArrayData ba CUChar  = AD_CUChar  (ba Word8)
 data instance GArrayData ba (a, b)  = AD_Pair (GArrayData ba a)
@@ -455,7 +460,7 @@ instance ArrayElt Char where
   arrayElt                              = ArrayEltRchar
 
 instance ArrayElt CChar where
-  type ArrayPtrs CChar = Ptr Int8
+  type ArrayPtrs CChar = Ptr HTYPE_CHAR
   unsafeIndexArrayData (AD_CChar ba) i   = CChar $ unsafeIndexArray ba i
   ptrsOfArrayData (AD_CChar ba)          = storableArrayPtr ba
   newArrayData size                      = liftM AD_CChar $ unsafeNewArray_ (0,size-1)


### PR DESCRIPTION
On ARM `CChar` is `Word8` not `Int8` (as on `x86_64`). This checks if `CChar` is signed and insert the appropriate data types.
