### PR TITLE
Consolidate Typeable tuple instances with base-orphans

### DIFF
--- a/Data/Array/Accelerate/Type.hs
+++ b/Data/Array/Accelerate/Type.hs
@@ -38,6 +38,8 @@ module Data.Array.Accelerate.Type (
   module Data.Array.Accelerate.Type
 ) where
 
+-- Imports Typeable instances for 8-tuples and beyond
+import Data.Orphans ()
 -- standard libraries
 import Data.Bits
 import Data.Int
@@ -48,20 +50,6 @@ import Foreign.C.Types (
   CChar, CSChar, CUChar, CShort, CUShort, CInt, CUInt, CLong, CULong,
   CLLong, CULLong, CFloat, CDouble)
   -- in the future, CHalf
-
-
--- Extend Typeable support for 8-tuple and beyond
--- ----------------------------------------------
-
-deriving instance Typeable (,,,,,,,)
-deriving instance Typeable (,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,)
-deriving instance Typeable (,,,,,,,,,,,,,,)
-
 
 -- Scalar types
 -- ------------

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -168,6 +168,7 @@ Flag internal-checks
 Library
   Build-depends:        array                   >= 0.3,
                         base                    >= 4.7,
+                        base-orphans            >= 0.3,
                         containers              >= 0.3,
                         exceptions              >= 0.6,
                         unordered-containers    >= 0.2,


### PR DESCRIPTION
Currently, `accelerate` defines orphan `Typeable` instances for tuple types. `base-orphans` also exports these instances, so to avoid potential instance conflicts with [other packages](http://packdeps.haskellers.com/reverse/base-orphans) that transitively depend on `base-orphans` (e.g., [`hsbencher`](https://github.com/rrnewton/HSBencher/pull/91)), this pull request imports [these instances](https://github.com/haskell-compat/base-orphans/blob/0a62d9e77e9fd242540b1e6e104ead9128e93ad1/src/Data/Orphans.hs#L1315-1369) from `Data.Orphans` instead.