### PR TITLE
Fix the Windows build

### DIFF
--- a/Data/Array/Accelerate/Debug.hs
+++ b/Data/Array/Accelerate/Debug.hs
@@ -112,10 +112,9 @@ withTemporaryFile template go = do
   let dir = tmp </> "accelerate-" ++ show pid
   createDirectoryIfMissing True dir
   bracket (openTempFile dir template) (hClose . snd) (uncurry go)
-#endif
 
 #ifdef WIN32
 getProcessID :: IO ProcessId
 getProcessID = return 0xaaaa
 #endif
-
+#endif

--- a/Data/Array/Accelerate/Type.hs
+++ b/Data/Array/Accelerate/Type.hs
@@ -645,7 +645,7 @@ type instance BitSize CLong  = $( case finiteBitSize (undefined::CLong) of
                                     _  -> error "I don't know what architecture I am"  )
 
 
-type instance BitSize CULong = $( case finiteBitSize (undefined::CULLong) of
+type instance BitSize CULong = $( case finiteBitSize (undefined::CULong) of
                                     32 -> [t| 32 |]
                                     64 -> [t| 64 |]
                                     _  -> error "I don't know what architecture I am"  )


### PR DESCRIPTION
There were two sneaky issues preventing `accelerate` from building on Windows:

1. There was a mysterious error about `ProcessId` being out of scope in `Data.Array.Accelerate.Debug`. As it turns out, `ProcessId` was only being imported if `ACCELERATE_DEBUG` was on, and `ProcessId` wasn't being used within an `#if ACCELERATE_DEBUG ... #endif`.

2. Even more mysteriously, `rotateDefault` was failing to typecheck. This led me to discover that the `BitSize CULong` instance was using the size of `CULLong`, not `CULong`! This matters for Windows, since the size of `CULong` is 4 bytes, and the size of `CULLong` is 8 bytes.