### PR TITLE
Generalize ArraysFunit and ArraysFarray

### DIFF
--- a/Data/Array/Accelerate/Array/Sugar.hs
+++ b/Data/Array/Accelerate/Array/Sugar.hs
@@ -627,9 +627,9 @@ data ArraysR arrs where
   ArraysRpair  :: ArraysR arrs1 -> ArraysR arrs2 -> ArraysR (arrs1, arrs2)
 
 data ArraysFlavour arrs where
-  ArraysFunit  ::                                          ArraysFlavour ()
-  ArraysFarray :: (Shape sh, Elt e)                     => ArraysFlavour (Array sh e)
-  ArraysFtuple :: (IsAtuple arrs, ArrRepr arrs ~ (l,r)) => ArraysFlavour arrs
+  ArraysFunit  :: ArrRepr arrs ~ ()                            => ArraysFlavour arrs
+  ArraysFarray :: (Shape sh, Elt e, ArrRepr arrs ~ Array sh e) => ArraysFlavour arrs
+  ArraysFtuple :: (IsAtuple arrs, ArrRepr arrs ~ (l,r))        => ArraysFlavour arrs
 
 -- | 'Arrays' consists of nested tuples of individual 'Array's, currently up to
 -- 15-elements wide. Accelerate computations can thereby return multiple


### PR DESCRIPTION
This is my attempt at solving issue #263 by generalizing the types of ArraysFunit and ArraysFarray. The idea is to change the definition to only place constraints on the type of ArrRepr arrs rather than on the type of arrs. This should allow Arrays instances to be defined for any type with a valid ArrRepr.

My feeling is that more simplification is possible here, but I don't yet understand well enough how everything fits together. For example it seems like it should be possible to remove the second argument from LiftedRepr and perhaps simplify the relationships between IsProduct, Arrays, and the Lifted machinery. Looking through old github issues, I see some similar sentiments expressed in issue #210.

As I'm not yet sure about how to tackle simplifying these, I am hoping that this commit will address the issue of custom Arrays instances while remaining minimally invasive.