### PR TITLE
Fix the build with GHC 8.4

### DIFF
--- a/src/Data/Array/Accelerate/Classes/FromIntegral.hs
+++ b/src/Data/Array/Accelerate/Classes/FromIntegral.hs
@@ -61,10 +61,16 @@ $(runQ $ do
           TyConI (DataD _ _ _ _ cons _) <- reify name
 #endif
           let
+            -- This is what a constructor such as IntegralNumType will be reified
+            -- as prior to GHC 8.4...
             dig (NormalC _ [(_, AppT (ConT n) (VarT _))])               = digItOut n
 #if __GLASGOW_HASKELL__ < 800
             dig (ForallC _ _ (NormalC _ [(_, AppT (ConT _) (ConT n))])) = return [n]
 #else
+            -- ...but this is what IntegralNumType will be reified as on GHC 8.4
+            -- and later, after the changes described in
+            -- https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#TemplateHaskellreificationchangesforGADTs
+            dig (ForallC _ _ (GadtC _ [(_, AppT (ConT n) (VarT _))] _)) = digItOut n
             dig (GadtC _ _ (AppT (ConT _) (ConT n)))                    = return [n]
 #endif
             dig _ = error "Unexpected case generating FromIntegral instances"

--- a/src/Data/Array/Accelerate/Classes/ToFloating.hs
+++ b/src/Data/Array/Accelerate/Classes/ToFloating.hs
@@ -57,10 +57,16 @@ $(runQ $ do
           TyConI (DataD _ _ _ _ cons _) <- reify name
 #endif
           let
+            -- This is what a constructor such as IntegralNumType will be reified
+            -- as prior to GHC 8.4...
             dig (NormalC _ [(_, AppT (ConT n) (VarT _))])               = digItOut n
 #if __GLASGOW_HASKELL__ < 800
             dig (ForallC _ _ (NormalC _ [(_, AppT (ConT _) (ConT n))])) = return [n]
 #else
+            -- ...but this is what IntegralNumType will be reified as on GHC 8.4
+            -- and later, after the changes described in
+            -- https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#TemplateHaskellreificationchangesforGADTs
+            dig (ForallC _ _ (GadtC _ [(_, AppT (ConT n) (VarT _))] _)) = digItOut n
             dig (GadtC _ _ (AppT (ConT _) (ConT n)))                    = return [n]
 #endif
             dig _ = error "Unexpected case generating ToFloating instances"

--- a/src/Data/Array/Accelerate/Data/Monoid.hs
+++ b/src/Data/Array/Accelerate/Data/Monoid.hs
@@ -29,6 +29,7 @@ module Data.Array.Accelerate.Data.Monoid (
 
 import Data.Array.Accelerate
 import Data.Array.Accelerate.Array.Sugar
+import Data.Array.Accelerate.Data.Semigroup                         ()
 import Data.Array.Accelerate.Product
 import Data.Array.Accelerate.Smart                                  ( Exp(..), PreExp(..) )
 import Data.Array.Accelerate.Type
@@ -198,31 +199,3 @@ instance (Elt a, Elt b, Elt c, Elt d, Elt e, Monoid (Exp a), Monoid (Exp b), Mon
                 in
                 lift (a1 `mappend` a2, b1 `mappend` b2, c1 `mappend` c2, d1 `mappend` d2, e1 `mappend` e2)
 
-#if __GLASGOW_HASKELL__ >= 800
-instance Semigroup (Exp ()) where
-  _ <> _ = constant ()
-
-instance (Elt a, Elt b, Semigroup (Exp a), Semigroup (Exp b)) => Semigroup (Exp (a,b)) where
-  x <> y      = let (a1,b1) = unlift x  :: (Exp a, Exp b)
-                    (a2,b2) = unlift y
-                in
-                lift (a1 <> a2, b1 <> b2)
-
-instance (Elt a, Elt b, Elt c, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c)) => Semigroup (Exp (a,b,c)) where
-  x <> y      = let (a1,b1,c1) = unlift x  :: (Exp a, Exp b, Exp c)
-                    (a2,b2,c2) = unlift y
-                in
-                lift (a1 <> a2, b1 <> b2, c1 <> c2)
-
-instance (Elt a, Elt b, Elt c, Elt d, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c), Semigroup (Exp d)) => Semigroup (Exp (a,b,c,d)) where
-  x <> y      = let (a1,b1,c1,d1) = unlift x  :: (Exp a, Exp b, Exp c, Exp d)
-                    (a2,b2,c2,d2) = unlift y
-                in
-                lift (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2)
-
-instance (Elt a, Elt b, Elt c, Elt d, Elt e, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c), Semigroup (Exp d), Semigroup (Exp e)) => Semigroup (Exp (a,b,c,d,e)) where
-  x <> y      = let (a1,b1,c1,d1,e1) = unlift x  :: (Exp a, Exp b, Exp c, Exp d, Exp e)
-                    (a2,b2,c2,d2,e2) = unlift y
-                in
-                lift (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2, e1 <> e2)
-#endif

--- a/src/Data/Array/Accelerate/Data/Monoid.hs
+++ b/src/Data/Array/Accelerate/Data/Monoid.hs
@@ -198,3 +198,31 @@ instance (Elt a, Elt b, Elt c, Elt d, Elt e, Monoid (Exp a), Monoid (Exp b), Mon
                 in
                 lift (a1 `mappend` a2, b1 `mappend` b2, c1 `mappend` c2, d1 `mappend` d2, e1 `mappend` e2)
 
+#if __GLASGOW_HASKELL__ >= 800
+instance Semigroup (Exp ()) where
+  _ <> _ = constant ()
+
+instance (Elt a, Elt b, Semigroup (Exp a), Semigroup (Exp b)) => Semigroup (Exp (a,b)) where
+  x <> y      = let (a1,b1) = unlift x  :: (Exp a, Exp b)
+                    (a2,b2) = unlift y
+                in
+                lift (a1 <> a2, b1 <> b2)
+
+instance (Elt a, Elt b, Elt c, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c)) => Semigroup (Exp (a,b,c)) where
+  x <> y      = let (a1,b1,c1) = unlift x  :: (Exp a, Exp b, Exp c)
+                    (a2,b2,c2) = unlift y
+                in
+                lift (a1 <> a2, b1 <> b2, c1 <> c2)
+
+instance (Elt a, Elt b, Elt c, Elt d, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c), Semigroup (Exp d)) => Semigroup (Exp (a,b,c,d)) where
+  x <> y      = let (a1,b1,c1,d1) = unlift x  :: (Exp a, Exp b, Exp c, Exp d)
+                    (a2,b2,c2,d2) = unlift y
+                in
+                lift (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2)
+
+instance (Elt a, Elt b, Elt c, Elt d, Elt e, Semigroup (Exp a), Semigroup (Exp b), Semigroup (Exp c), Semigroup (Exp d), Semigroup (Exp e)) => Semigroup (Exp (a,b,c,d,e)) where
+  x <> y      = let (a1,b1,c1,d1,e1) = unlift x  :: (Exp a, Exp b, Exp c, Exp d, Exp e)
+                    (a2,b2,c2,d2,e2) = unlift y
+                in
+                lift (a1 <> a2, b1 <> b2, c1 <> c2, d1 <> d2, e1 <> e2)
+#endif

--- a/src/Data/Array/Accelerate/Data/Monoid.hs
+++ b/src/Data/Array/Accelerate/Data/Monoid.hs
@@ -29,7 +29,9 @@ module Data.Array.Accelerate.Data.Monoid (
 
 import Data.Array.Accelerate
 import Data.Array.Accelerate.Array.Sugar
+#if __GLASGOW_HASKELL__ >= 800
 import Data.Array.Accelerate.Data.Semigroup                         ()
+#endif
 import Data.Array.Accelerate.Product
 import Data.Array.Accelerate.Smart                                  ( Exp(..), PreExp(..) )
 import Data.Array.Accelerate.Type


### PR DESCRIPTION
A couple of changes are required in order to make `accelerate` build with GHC 8.4:

* Since `Semigroup` has become a superclass of `Monoid`, `Semigroup` instances need to be ~~added~~ in scope in `Data.Array.Accelerate.Data.Monoid`.
* GHC 8.4 [slightly changes the way it reifies GADTs](https://ghc.haskell.org/trac/ghc/wiki/Migration/8.4#TemplateHaskellreificationchangesforGADTs), and as a result, some of the plumbing code in `Data.Array.Accelerate.Classes.ToFloating` and `Data.Array.Accelerate.Classes.FromIntegral` has to be updated, or else you'll end up with an error like:

```
Data/Array/Accelerate/Classes/ToFloating.hs:1:1: error:
    Exception when trying to run compile-time code:
      Unexpected case generating ToFloating instances
CallStack (from HasCallStack):
  error, called at ./Data/Array/Accelerate/Classes/ToFloating.hs:66:21 in accelerate-1.1.1.0-inplace:Data.Array.Accelerate.Classes.ToFloating
    Code: runQ
            $ do let digItOut :: Name -> Q [Name]
                     ....
                 as <- digItOut ''NumType
                 bs <- digItOut ''FloatingType
                 ....
  |
1 | {-# LANGUAGE CPP                   #-}
  | ^
```