### PR TITLE
WIP : add Vector.Generic (Array DIM1) instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+ghc720:
+	stack build --stack-yaml stack-7.10.yaml
+
+ghc80:
+	stack build --stack-yaml stack-8.0.yaml
+
+ghc82:
+	stack build --stack-yaml stack-8.2.yaml
+
+ghc84:
+	stack build --stack-yaml stack-8.4.yaml

--- a/src/Data/Array/Accelerate/Array/Sugar.hs
+++ b/src/Data/Array/Accelerate/Array/Sugar.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TypeFamilies          #-}
 {-# LANGUAGE TypeOperators         #-}
 {-# LANGUAGE UndecidableInstances  #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 #if __GLASGOW_HASKELL__ <= 708
 {-# OPTIONS_GHC -fno-warn-unrecognised-pragmas #-}
@@ -70,6 +71,8 @@ import Prelude                                                  hiding ( (!!) )
 import Language.Haskell.TH                                      hiding ( Foreign )
 import qualified GHC.Exts                                       as GHC
 import qualified Data.Vector.Unboxed                            as U
+import qualified Data.Vector.Generic                            as VG
+import qualified Data.Vector.Generic.Mutable.Base               as VGM
 
 -- friends
 import Data.Array.Accelerate.Array.Data
@@ -965,6 +968,10 @@ instance Elt e => IsList (Vector e) where
   toList         = toList
   fromListN n xs = fromList (Z:.n) xs
   fromList xs    = GHC.fromListN (length xs) xs
+
+instance (VGM.MVector (VG.Mutable (Array DIM1)) e, Elt e) => VG.Vector (Array DIM1) e where
+  basicLength = length . toList
+  
 
 instance NFData (Array sh e) where
   rnf (Array sh ad) = Repr.size sh `seq` go arrayElt ad `seq` ()


### PR DESCRIPTION
## Description

* Started implementing Vector.Generic instance for Array DIM1
* Added basic makefile as shorthand for `stack build ..`

This is still a WIP because I'm unsure on how to proceed : many of the relevant accelerate functions return in the `Exp` monad, but the Vector methods require pure values to be returned. 
I've only written `length` so far but it requires `toList`, which I'm not sure will be fused away.


## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

Addresses #419 

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

