### PR TITLE
add lift instance for half/cushort so this builds

### DIFF
--- a/src/Data/Array/Accelerate/Type.hs
+++ b/src/Data/Array/Accelerate/Type.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveDataTypeable   #-}
+{-# LANGUAGE DeriveLift           #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
+{-# LANGUAGE StandaloneDeriving   #-}
 {-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
@@ -85,11 +87,12 @@ import Data.Typeable
 import Data.Word
 import GHC.TypeLits
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax (Lift)
 import Numeric.Half
 import Text.Printf
 import Foreign.Storable
 import Foreign.C.Types
-    (CChar, CSChar, CUChar, CShort, CUShort, CInt, CUInt, CLong, CULong, CLLong, CULLong, CFloat, CDouble)
+    (CChar, CSChar, CUChar, CShort, CUShort(CUShort), CInt, CUInt, CLong, CULong, CLLong, CULLong, CFloat, CDouble)
 
 
 -- Scalar types
@@ -538,3 +541,5 @@ $( runQ $ do
   return (concat is ++ concat fs ++ concat ns ++ concat vs)
  )
 
+deriving instance Lift Half
+deriving instance Lift CUShort


### PR DESCRIPTION
master didn't build for me, it complained about 'Half' not having a TemplateHaskell 'Lift' instance, so I added it, and now master builds