### PR TITLE
Mark nofib tests as non-buildable if flag is missing

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -562,6 +562,9 @@ test-suite nofib-interpreter
   hs-source-dirs:       test/nofib
   main-is:              Main.hs
 
+  if !flag(nofib)
+    buildable: False
+
   build-depends:
           base                          >= 4.9
         , accelerate


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->

Add `buildable: False` to the nofib-interpreter test-suite if the nofib flag is missing. 

## Motivation and context
The issue was that running `cabal test` gave an error because it tried to run the nofib test-suite without the nofib flag.

## How has this been tested?

I tested it on my machine with `cabal test` now it only runs the doctests.

I also tested if `cabal test -fnofib` still works and it does.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

