### PR TITLE
Fix multiple writes to the same address in expand

### DIFF
--- a/src/Data/Array/Accelerate/Prelude.hs
+++ b/src/Data/Array/Accelerate/Prelude.hs
@@ -2538,7 +2538,15 @@ expand f g xs =
           iotas      = map snd
                      $ scanl1 (segmentedL const)
                      $ zip head_flags
-                     $ permute const (fill (I1 n) undef) put
+                     $ permute const
+                               (fill (I1 n) undef)
+                               -- If any of the elements expand to zero new
+                               -- elements then this would result in multiple
+                               -- writes to the same index since the offsets are
+                               -- also the same, which is undefined behaviour
+                               (\ix -> if szs ! ix > 0
+                                         then put ix
+                                         else Nothing_)
                      $ enumFromN (shape xs) 0
       in
       zipWith g (gather iotas xs) idxs


### PR DESCRIPTION
**Description**
This resolves a memory corruption issue in `expand` when certain elements expand to 0 new elements caused by multiple`permute const` writes to the same memory address.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

There should definitely be some tests to catch issues like this for `expand` and some of the other prelude functions. I'll get to that next!