### PR TITLE
Pretty printing fixes

### DIFF
--- a/src/Data/Array/Accelerate/Pretty/Print.hs
+++ b/src/Data/Array/Accelerate/Pretty/Print.hs
@@ -140,7 +140,7 @@ prettyPreOpenAcc ctx prettyAcc extractAcc aenv pacc =
   case pacc of
     Avar (Var _ idx)        -> prj idx aenv
     Alet{}                  -> prettyAlet ctx prettyAcc extractAcc aenv pacc
-    Apair{}                 -> prettyAtuple prettyAcc extractAcc aenv pacc
+    Apair{}                 -> prettyAtuple ctx prettyAcc extractAcc aenv pacc
     Anil                    -> "()"
     Apply _ f a             -> apply
       where
@@ -261,18 +261,19 @@ prettyAlet ctx prettyAcc extractAcc aenv0
 
 prettyAtuple
     :: forall acc aenv arrs.
-       PrettyAcc acc
+       Context
+    -> PrettyAcc acc
     -> ExtractAcc acc
     -> Val aenv
     -> PreOpenAcc acc aenv arrs
     -> Adoc
-prettyAtuple prettyAcc extractAcc aenv0 acc = case collect acc of
+prettyAtuple ctx prettyAcc extractAcc aenv0 acc = case collect acc of
     Nothing  -> align $ ppPair acc
     Just tup ->
       case tup of
         []  -> "()"
         [t] -> t
-        _   -> align $ "T" <> pretty (length tup) <+> sep tup
+        _   -> align $ parensIf (ctxPrecedence ctx > 0) ("T" <> pretty (length tup) <+> sep tup)
   where
     ppPair :: PreOpenAcc acc aenv arrs' -> Adoc
     ppPair (Apair a1 a2) = "(" <> ppPair (extractAcc a1) <> "," <+> prettyAcc context0 aenv0 a2 <> ")"

--- a/src/Data/Array/Accelerate/Pretty/Print.hs
+++ b/src/Data/Array/Accelerate/Pretty/Print.hs
@@ -225,7 +225,7 @@ prettyAlet
     -> PreOpenAcc acc aenv arrs
     -> Adoc
 prettyAlet ctx prettyAcc extractAcc aenv0
-  = parensIf (needsParens ctx "let")
+  = parensIf (ctxPrecedence ctx > 0)
   . align . wrap . collect aenv0
   where
     collect :: Val aenv' -> PreOpenAcc acc aenv' a -> ([Adoc], Adoc)
@@ -456,7 +456,7 @@ prettyLet
     -> OpenExp env aenv t
     -> Adoc
 prettyLet ctx env0 aenv
-  = parensIf (needsParens ctx "let")
+  = parensIf (ctxPrecedence ctx > 0)
   . align . wrap . collect env0
   where
     collect :: Val env' -> OpenExp env' aenv e -> ([Adoc], Adoc)


### PR DESCRIPTION
**Description**
Fixes for some of the issues in #470. (See also the commit descriptions.) I believe the `T1` issue is strictly speaking not an issue, as I find it likely the `T1` just indicates a `((), _)` construction.

Discussion point: How do we test pretty printing things?

I didn't fix the single-line let clause separation issue yet, because it's not as trivial as the two I did fix. I believe the do-notation example under [`flatAlt` in the prettyprinter documentation](https://hackage.haskell.org/package/prettyprinter-1.7.0/docs/Prettyprinter.html#v:flatAlt) could be adapted to our let-bindings, but I'm not fully certain, as the current implementation is quite different.

**Motivation and context**
Syntactically unambiguous pretty-printing output is useful for a human reader, as well as if one tries to feed pretty-printed output back into Accelerate as Haskell code.

**How has this been tested?**
The examples in #470 have been tested.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

