### PR TITLE
Pretty printing fixes: remove T1 special case

### DIFF
--- a/src/Data/Array/Accelerate/Pretty/Print.hs
+++ b/src/Data/Array/Accelerate/Pretty/Print.hs
@@ -272,7 +272,6 @@ prettyAtuple ctx prettyAcc extractAcc aenv0 acc = case collect acc of
     Just tup ->
       case tup of
         []  -> "()"
-        [t] -> t
         _   -> align $ parensIf (ctxPrecedence ctx > 0) ("T" <> pretty (length tup) <+> align (sep tup))
   where
     ppPair :: PreOpenAcc acc aenv arrs' -> Adoc
@@ -505,7 +504,6 @@ prettyTuple ctx env aenv exp = case collect exp of
     Just tup ->
       case tup of
         []  -> "()"
-        [t] -> t
         _   -> align $ parensIf (ctxPrecedence ctx > 0) ("T" <> pretty (length tup) <+> align (sep tup))
   where
     ppPair :: OpenExp env aenv t' -> Adoc


### PR DESCRIPTION
**Description**
When printing a left-hand side, T1's were already explicitly printed, so this change introduces more consistency.
The alternative, where T1's would also be elided in a left-hand side, would also be consistent, but then we introduce more ambiguity, which can be confusing.

**Motivation and context**
See the example here: https://github.com/AccelerateHS/accelerate/issues/470#issuecomment-720402900

**How has this been tested?**
Only minorly tested.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

