### PR TITLE
Fix some typos in the documentation comments in AST

### DIFF
--- a/src/Data/Array/Accelerate/AST.hs
+++ b/src/Data/Array/Accelerate/AST.hs
@@ -208,8 +208,8 @@ type PrimMaybe a = (TAG, ((), a))
 --   need to hoist array expressions out of scalar expressions---they occur
 --   in scalar indexing and in determining an arrays shape.)
 --
--- The data type is parameterised over the surface types (not the
--- representation type).
+-- The data type is parameterised over the representation types (not the
+-- surface type).
 --
 -- We use a non-recursive variant parametrised over the recursive closure,
 -- to facilitate attribute calculation in the backend.
@@ -393,7 +393,7 @@ data PreOpenAcc (acc :: Type -> Type -> Type) aenv a where
   -- Other characteristics of the permutation function 'f':
   --
   --   1. 'f' is a (morally) partial function: only the elements of the domain
-  --      for which the function evealuates to a 'Just' value are mapped in the
+  --      for which the function evaluates to a 'Just' value are mapped in the
   --      result. Other elements are dropped.
   --
   --   2. 'f' is not surjective: positions in the target array need not be


### PR DESCRIPTION
**Description**
This fixes a typo and an outdated reference to surface types in the comments in AST.hs.

**Motivation and context**
General maintenance, I guess.

**How has this been tested?**
n/a, only comments

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation fix

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
