### PR TITLE
Make cabal flags manual

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -144,6 +144,7 @@ custom-setup
     , cabal-doctest     >= 1.0
 
 flag debug
+  manual:               True
   default:              False
   description:
     Enable debug tracing messages. The following options are read from the
@@ -221,6 +222,7 @@ flag debug
     .
 
 flag ekg
+  manual:               True
   default:              False
   description:
     Enable hooks for monitoring the running application using EKG. Implies
@@ -257,20 +259,24 @@ flag ekg
     .
 
 flag bounds-checks
-  description:          Enable bounds checking
+  manual:               True
   default:              True
+  description:          Enable bounds checking
 
 flag unsafe-checks
-  description:          Enable bounds checking in unsafe operations
+  manual:               True
   default:              False
+  description:          Enable bounds checking in unsafe operations
 
 flag internal-checks
-  description:          Enable internal consistency checks
+  manual:               True
   default:              False
+  description:          Enable internal consistency checks
 
 -- Enabling this drastically increases build times
 -- See: https://gitlab.haskell.org/ghc/ghc/issues/15751
 flag nofib
+  manual:               True
   default:              False
   description:          Build the nofib test suite (required for backend testing)
 


### PR DESCRIPTION
**Description**
This patch changes all cabal flags to `manual` in `accelerate.cabal`.

**Motivation and context**
This prevents Cabal from automatically assigning flags in the constraint solver. This currently cannot result in issues: if any build configuration is valid, the default one is valid too. However, using 'manual' flags makes this future-proof against changes within Accelerate, and also changes within Cabal: with 'manual' we select the semantically correct type of flag.

This should not adversely affect anything, especially since the flags are only meant for Accelerate developers and testers anyway.

**How has this been tested?**
Accelerate still builds.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

