### PR TITLE
Add Acc debugging functionality similar to Debug.Trace

### DIFF
--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -290,6 +290,9 @@ module Data.Array.Accelerate (
   Stencil3x3x3, Stencil5x3x3, Stencil3x5x3, Stencil3x3x5, Stencil5x5x3, Stencil5x3x5,
   Stencil3x5x5, Stencil5x5x5,
 
+  -- *** Debugging
+  atrace, atraceArray, atraceId, atraceExp,
+
   -- -- ** Sequence operations
   -- collect,
 

--- a/src/Data/Array/Accelerate/AST.hs
+++ b/src/Data/Array/Accelerate/AST.hs
@@ -150,6 +150,7 @@ import Data.Primitive.Vec
 import Control.DeepSeq
 import Data.Kind
 import Language.Haskell.TH                                          ( Q, TExp )
+import qualified Language.Haskell.TH.Syntax as TH
 import Prelude
 
 import GHC.TypeLits
@@ -272,6 +273,10 @@ data PreOpenAcc (acc :: Type -> Type -> Type) aenv a where
               -> acc             aenv arrs                      -- initial value
               -> PreOpenAcc  acc aenv arrs
 
+  Atrace      :: String
+              -> acc             aenv arrs1
+              -> acc             aenv arrs2
+              -> PreOpenAcc  acc aenv arrs2
 
   -- Array inlet. Triggers (possibly) asynchronous host->device transfer if
   -- necessary.
@@ -754,6 +759,7 @@ instance HasArraysR acc => HasArraysR (PreOpenAcc acc) where
   arraysR (Avar (Var aR _))           = TupRsingle aR
   arraysR (Apair as bs)               = TupRpair (arraysR as) (arraysR bs)
   arraysR Anil                        = TupRunit
+  arraysR (Atrace _ _ bs)             = arraysR bs
   arraysR (Apply aR _ _)              = aR
   arraysR (Aforeign r _ _ _)          = r
   arraysR (Acond _ a _)               = arraysR a
@@ -974,6 +980,7 @@ rnfPreOpenAcc rnfA pacc =
     Avar var                  -> rnfArrayVar var
     Apair as bs               -> rnfA as `seq` rnfA bs
     Anil                      -> ()
+    Atrace msg as bs          -> rnf msg `seq` rnfA as `seq` rnfA bs
     Apply repr afun acc       -> rnfTupR rnfArrayR repr `seq` rnfAF afun `seq` rnfA acc
     Aforeign repr asm afun a  -> rnfTupR rnfArrayR repr `seq` rnf (strForeign asm) `seq` rnfAF afun `seq` rnfA a
     Acond p a1 a2             -> rnfE p `seq` rnfA a1 `seq` rnfA a2
@@ -1182,6 +1189,7 @@ liftPreOpenAcc liftA pacc =
     Avar var                  -> [|| Avar $$(liftArrayVar var) ||]
     Apair as bs               -> [|| Apair $$(liftA as) $$(liftA bs) ||]
     Anil                      -> [|| Anil ||]
+    Atrace msg as bs          -> [|| Atrace $$(TH.unsafeTExpCoerce $ return $ TH.LitE $ TH.StringL msg) $$(liftA as) $$(liftA bs) ||]
     Apply repr f a            -> [|| Apply $$(liftArraysR repr) $$(liftAF f) $$(liftA a) ||]
     Aforeign repr asm f a     -> [|| Aforeign $$(liftArraysR repr) $$(liftForeign asm) $$(liftPreOpenAfun liftA f) $$(liftA a) ||]
     Acond p t e               -> [|| Acond $$(liftE p) $$(liftA t) $$(liftA e) ||]
@@ -1366,6 +1374,7 @@ showPreAccOp :: forall acc aenv arrs. PreOpenAcc acc aenv arrs -> String
 showPreAccOp Alet{}              = "Alet"
 showPreAccOp (Avar (Var _ ix))   = "Avar a" ++ show (idxToInt ix)
 showPreAccOp (Use aR a)          = "Use " ++ showArrayShort 5 (showsElt (arrayRtype aR)) aR a
+showPreAccOp Atrace{}            = "Atrace"
 showPreAccOp Apply{}             = "Apply"
 showPreAccOp Aforeign{}          = "Aforeign"
 showPreAccOp Acond{}             = "Acond"

--- a/src/Data/Array/Accelerate/Analysis/Hash.hs
+++ b/src/Data/Array/Accelerate/Analysis/Hash.hs
@@ -49,6 +49,7 @@ import Data.Array.Accelerate.Type
 import Data.Primitive.Vec
 
 import Crypto.Hash
+import qualified Data.Hashable as Hashable
 import Data.ByteString.Builder
 import Data.ByteString.Builder.Extra
 import Data.ByteString.Short.Internal                               ( ShortByteString(..) )
@@ -168,6 +169,7 @@ encodePreOpenAcc options encodeAcc pacc =
     Avar (Var repr v)            -> intHost $(hashQ "Avar")        <> encodeArrayType repr <> deep (encodeIdx v)
     Apair a1 a2                  -> intHost $(hashQ "Apair")       <> travA a1 <> travA a2
     Anil                         -> intHost $(hashQ "Anil")
+    Atrace msg as bs             -> intHost $(hashQ "Atrace")      <> intHost (Hashable.hash msg) <> travA as <> travA bs
     Apply _ f a                  -> intHost $(hashQ "Apply")       <> travAF f <> travA a
     Aforeign _ _ f a             -> intHost $(hashQ "Aforeign")    <> travAF f <> travA a
     Use repr a                   -> intHost $(hashQ "Use")         <> encodeArrayType repr <> deep (encodeArray a)

--- a/src/Data/Array/Accelerate/Language.hs
+++ b/src/Data/Array/Accelerate/Language.hs
@@ -73,6 +73,9 @@ module Data.Array.Accelerate.Language (
   Stencil3x3x3, Stencil5x3x3, Stencil3x5x3, Stencil3x3x5, Stencil5x5x3, Stencil5x3x5,
   Stencil3x5x5, Stencil5x5x5,
 
+  -- * Debugging
+  atrace, atraceArray, atraceId, atraceExp,
+
   -- * Foreign functions
   foreignAcc,
   foreignExp,
@@ -118,7 +121,7 @@ import Data.Array.Accelerate.Classes.Integral
 import Data.Array.Accelerate.Classes.Num
 import Data.Array.Accelerate.Classes.Ord
 
-import Prelude                                                      ( ($), (.), Maybe(..), Char )
+import Prelude                                                      ( ($), (.), Maybe(..), Char, String )
 
 
 -- $setup
@@ -1171,6 +1174,46 @@ foldSeqFlatten = Seq $$$ FoldSeqFlatten
 collect :: Arrays arrs => Seq arrs -> Acc arrs
 collect = Acc . Collect
 --}
+
+-- Debugging
+-- ---------
+
+-- | Outputs the trace message to the console before the 'Acc' computation can proceed
+-- with the result of the second argument.
+--
+-- Note that arrays are printed in their internal representation (using 'ArraysR'),
+-- which causes that tuples or custom data types are shown differently.
+--
+atrace :: Arrays as => String -> Acc as -> Acc as
+atrace message = atraceArray message (Acc $ SmartAcc Anil :: Acc ())
+
+-- | Outputs the trace message and the array(s) from the second argument to the console,
+-- before the 'Acc' computation can proceed with the result of the third argument.
+--
+-- Note that arrays are printed in their internal representation (using 'ArraysR'),
+-- which causes that tuples or custom data types are shown differently.
+--
+atraceArray :: (Arrays as, Arrays bs) => String -> Acc as -> Acc bs -> Acc bs
+atraceArray message (Acc inspect) (Acc result) = Acc $ SmartAcc $ Atrace message inspect result
+
+-- | Outputs the trace message and the array(s) to the console,
+-- before the 'Acc' computation can proceed with the result of
+-- that array.
+--
+-- Note that arrays are printed in their internal representation (using 'ArraysR'),
+-- which causes that tuples or custom data types are shown differently.
+--
+atraceId :: Arrays as => String -> Acc as -> Acc as
+atraceId message value = atraceArray message value value
+
+-- | Outputs the trace message and a scalar value to the console,
+-- before the 'Acc' computation can prroceed with the result of the third argument.
+--
+-- Note that arrays are printed in their internal representation (using 'ArraysR'),
+-- which causes that tuples or custom data types are shown differently.
+--
+atraceExp :: (Elt e, Arrays as) => String -> Exp e -> Acc as -> Acc as
+atraceExp message = atraceArray message . unit
 
 -- Foreign function calling
 -- ------------------------

--- a/src/Data/Array/Accelerate/Pretty/Graphviz.hs
+++ b/src/Data/Array/Accelerate/Pretty/Graphviz.hs
@@ -230,6 +230,7 @@ prettyDelayedOpenAcc detail ctx aenv atop@(Manifest pacc) =
 
     Anil                     -> "()"             .$ []
 
+    Atrace msg as bs         -> "atrace"         .$ [ return $ PDoc (fromString msg) [], ppA as, ppA bs ]
     Use repr arr             -> "use"            .$ [ return $ PDoc (prettyArray repr arr) [] ]
     Unit _ e                 -> "unit"           .$ [ ppE e ]
     Generate _ sh f          -> "generate"       .$ [ ppE sh, ppF f ]

--- a/src/Data/Array/Accelerate/Pretty/Print.hs
+++ b/src/Data/Array/Accelerate/Pretty/Print.hs
@@ -142,6 +142,7 @@ prettyPreOpenAcc ctx prettyAcc extractAcc aenv pacc =
     Alet{}                  -> prettyAlet ctx prettyAcc extractAcc aenv pacc
     Apair{}                 -> prettyAtuple ctx prettyAcc extractAcc aenv pacc
     Anil                    -> "()"
+    Atrace msg as bs        -> "atrace" .$ [ fromString (show msg), ppA as, ppA bs ]
     Apply _ f a             -> apply
       where
         op    = Operator ">->" Infix L 1

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -354,6 +354,11 @@ data PreSmartAcc acc exp as where
                 -> acc (arrs1, arrs2)
                 -> PreSmartAcc acc exp arrs
 
+  Atrace        :: String
+                -> acc arrs1
+                -> acc arrs2
+                -> PreSmartAcc acc exp arrs2
+
   Use           :: ArrayR (Array sh e)
                 -> Array sh e
                 -> PreSmartAcc acc exp (Array sh e)
@@ -799,6 +804,7 @@ instance HasArraysR acc => HasArraysR (PreSmartAcc acc exp) where
                                    PairIdxLeft  -> t1
                                    PairIdxRight -> t2
     Aprj _ _                  -> error "Ejector seat? You're joking!"
+    Atrace _ _ a              -> arraysR a
     Use repr _                -> TupRsingle repr
     Unit tp _                 -> TupRsingle $ ArrayR ShapeRz $ tp
     Generate repr _ _         -> TupRsingle repr
@@ -1308,6 +1314,7 @@ showPreAccOp Awhile{}              = "Awhile"
 showPreAccOp Apair{}               = "Apair"
 showPreAccOp Anil{}                = "Anil"
 showPreAccOp Aprj{}                = "Aprj"
+showPreAccOp Atrace{}              = "Atrace"
 showPreAccOp Unit{}                = "Unit"
 showPreAccOp Generate{}            = "Generate"
 showPreAccOp Reshape{}             = "Reshape"

--- a/src/Data/Array/Accelerate/Trafo/Fusion.hs
+++ b/src/Data/Array/Accelerate/Trafo/Fusion.hs
@@ -176,6 +176,7 @@ manifest config (OpenAcc pacc) =
     Awhile p f a            -> Awhile (cvtAF p) (cvtAF f) (manifest config a)
     Apair a1 a2             -> Apair (manifest config a1) (manifest config a2)
     Anil                    -> Anil
+    Atrace msg a1 a2        -> Atrace msg (manifest config a1) (manifest config a2)
     Apply repr f a          -> apply repr (cvtAF f) (manifest config a)
     Aforeign repr ff f a    -> Aforeign repr ff (cvtAF f) (manifest config a)
 
@@ -366,6 +367,7 @@ embedPreOpenAcc config matchAcc embedAcc elimAcc pacc
     Apply aR f a        -> done $ Apply aR (cvtAF f) (cvtA a)
     Awhile p f a        -> done $ Awhile (cvtAF p) (cvtAF f) (cvtA a)
     Apair a1 a2         -> done $ Apair (cvtA a1) (cvtA a2)
+    Atrace msg a1 a2    -> done $ Atrace msg (cvtA a1) (cvtA a2)
     Aforeign aR ff f a  -> done $ Aforeign aR ff (cvtAF f) (cvtA a)
     -- Collect s           -> collectD s
 

--- a/src/Data/Array/Accelerate/Trafo/LetSplit.hs
+++ b/src/Data/Array/Accelerate/Trafo/LetSplit.hs
@@ -37,6 +37,7 @@ convertPreOpenAcc = \case
   Avar var                        -> Avar var
   Apair a1 a2                     -> Apair (convertAcc a1) (convertAcc a2)
   Anil                            -> Anil
+  Atrace msg as bs                -> Atrace msg (convertAcc as) (convertAcc bs)
   Apply repr f a                  -> Apply repr (convertAfun f) (convertAcc a)
   Aforeign repr asm f a           -> Aforeign repr asm (convertAfun f) (convertAcc a)
   Acond e a1 a2                   -> Acond e (convertAcc a1) (convertAcc a2)

--- a/src/Data/Array/Accelerate/Trafo/Sharing.hs
+++ b/src/Data/Array/Accelerate/Trafo/Sharing.hs
@@ -339,6 +339,7 @@ convertSharingAcc config alyt aenv (ScopedAcc lams (AccSharing _ preAcc))
       Apair acc1 acc2             -> AST.Apair (cvtA acc1) (cvtA acc2)
       Aprj ix a                   -> let AST.OpenAcc a' = cvtAprj ix a
                                      in a'
+      Atrace msg acc1 acc2        -> AST.Atrace msg (cvtA acc1) (cvtA acc2)
       Use repr array              -> AST.Use repr array
       Unit tp e                   -> AST.Unit tp (cvtE e)
       Generate repr@(ArrayR shr _) sh f
@@ -1502,6 +1503,10 @@ makeOccMapSharingAcc config accOccMap = traverseAcc
                                              return (Apair a' b', h1 `max` h2 + 1)
             Aprj ix a                   -> travA (Aprj ix) a
 
+            Atrace msg acc1 acc2        -> do
+                                             (a', h1) <- traverseAcc lvl acc1
+                                             (b', h2) <- traverseAcc lvl acc2
+                                             return (Atrace msg a' b', h1 `max` h2 + 1)
             Use repr arr                -> return (Use repr arr, 1)
             Unit tp e                   -> do
                                              (e', h) <- traverseExp lvl e
@@ -2358,6 +2363,11 @@ determineScopesSharingAcc config accOccMap = scopesAcc
                                        reconstruct (Apair a1' a2') (accCount1 +++ accCount2)
           Aprj ix a               -> travA (Aprj ix) a
 
+          Atrace msg a1 a2        -> let
+                                       (a1', accCount1) = scopesAcc a1
+                                       (a2', accCount2) = scopesAcc a2
+                                     in
+                                       reconstruct (Atrace msg a1' a2') (accCount1 +++ accCount2)
           Use repr arr            -> reconstruct (Use repr arr) noNodeCounts
           Unit tp e               -> let
                                        (e', accCount) = scopesExp e

--- a/src/Data/Array/Accelerate/Trafo/Shrink.hs
+++ b/src/Data/Array/Accelerate/Trafo/Shrink.hs
@@ -543,6 +543,7 @@ usesOfPreAcc withShape countAcc idx = count
       Alet lhs bnd body          -> countA bnd + countAcc withShape (weakenWithLHS lhs >:> idx) body
       Apair a1 a2                -> countA a1 + countA a2
       Anil                       -> 0
+      Atrace _ a1 a2             -> countA a1 + countA a2
       Apply _ f a                -> countAF f idx + countA a
       Aforeign _ _ _ a           -> countA a
       Acond p t e                -> countE p + countA t + countA e

--- a/src/Data/Array/Accelerate/Trafo/Substitution.hs
+++ b/src/Data/Array/Accelerate/Trafo/Substitution.hs
@@ -680,6 +680,7 @@ rebuildPreOpenAcc k av acc =
     Avar ix                   -> accOut          <$> av ix
     Apair as bs               -> Apair           <$> k av as <*> k av bs
     Anil                      -> pure Anil
+    Atrace msg as bs          -> Atrace msg      <$> k av as <*> k av bs
     Apply repr f a            -> Apply repr      <$> rebuildAfun k av f <*> k av a
     Acond p t e               -> Acond           <$> rebuildOpenExp (pure . IE) av' p <*> k av t <*> k av e
     Awhile p f a              -> Awhile          <$> rebuildAfun k av p <*> rebuildAfun k av f <*> k av a


### PR DESCRIPTION
**Description**
To make it easier to debug Accelerate programs, this PR adds functionality to inspect intermediate values of a computation, similar to what `Debug.Trace` provides for Haskell programs.

```haskell
-- | Outputs the trace message to the console before the 'Acc' computation can proceed
-- with the result of the second argument.
--
atrace :: Arrays as => String -> Acc as -> Acc as
atrace message = atraceArray message (Acc $ SmartAcc Anil :: Acc ())

-- | Outputs the trace message and the array(s) from the second argument to the console,
-- before the 'Acc' computation can proceed with the result of the third argument.
--
atraceArray :: (Arrays as, Arrays bs) => String -> Acc as -> Acc bs -> Acc bs
atraceArray message (Acc inspect) (Acc result) = Acc $ SmartAcc $ Atrace message inspect result

-- | Outputs the trace message and the array(s) to the console,
-- before the 'Acc' computation can proceed with the result of
-- that array.
--
atraceId :: Arrays as => String -> Acc as -> Acc as
atraceId message value = atraceArray message value value

-- | Outputs the trace message and a scalar value to the console,
-- before the 'Acc' computation can prroceed with the result of the third argument.
--
atraceExp :: (Elt e, Arrays as) => String -> Exp e -> Acc as -> Acc as
atraceExp message = atraceArray message . unit
```

Note that arrays are printed in their internal representation (using 'ArraysR'), which causes that tuples or custom data types are shown differently. In the current setup it is not possible to show them in the surface representation, as we do not have the link between those two representations. This link could be stored by storing the `Arrays` type class or a conversion function in the `Atrace` constructor, but then we wouldn't be able to implement lifting to Template Haskell any more.

The debugging is currently only supported on Acc-level. You can thus only inspect values during an Acc-computation. It is not yet possible to inspect values within Exp-context, which we may want to add in the feature. For GPU backends this may be more difficult to add though.

**Motivation and context**
This change makes it easier to debug Accelerate programs, which has been requested often.

**How has this been tested?**
I tested this in my Delta stepping implementation.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

