### PR TITLE
Add Monad, export Monad, Functor and Either

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -326,6 +326,7 @@ library
         Data.Array.Accelerate.Data.Fold
         Data.Array.Accelerate.Data.Functor
         Data.Array.Accelerate.Data.Maybe
+        Data.Array.Accelerate.Data.Monad
         Data.Array.Accelerate.Data.Monoid
         Data.Array.Accelerate.Data.Ratio
         Data.Array.Accelerate.Unsafe

--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -322,6 +322,8 @@ module Data.Array.Accelerate (
   Ord(..), Ordering(..), pattern LT_, pattern EQ_, pattern GT_,
   Enum, succ, pred,
   Bounded, minBound, maxBound,
+  Functor(..), (<$>), ($>), void,
+  Monad(..),
 
   -- *** Numeric type classes
   Num, (+), (-), (*), negate, abs, signum, fromInteger,
@@ -422,8 +424,9 @@ module Data.Array.Accelerate (
   Int, Int8, Int16, Int32, Int64,
   Word, Word8, Word16, Word32, Word64,
   Half(..), Float, Double,
-  Bool(..), pattern True_, pattern False_,
-  Maybe(..), pattern Nothing_, pattern Just_,
+  Bool(..),   pattern True_,    pattern False_,
+  Maybe(..),  pattern Nothing_, pattern Just_,
+  Either(..), pattern Left_,    pattern Right_,
   Char,
 
   CFloat, CDouble,
@@ -434,6 +437,7 @@ module Data.Array.Accelerate (
 
 import Data.Array.Accelerate.Classes
 import Data.Array.Accelerate.Data.Maybe
+import Data.Array.Accelerate.Data.Either
 import Data.Array.Accelerate.Language
 import Data.Array.Accelerate.Pattern
 import Data.Array.Accelerate.Pattern.TH

--- a/src/Data/Array/Accelerate/Classes.hs
+++ b/src/Data/Array/Accelerate/Classes.hs
@@ -20,6 +20,8 @@ module Data.Array.Accelerate.Classes (
   module Ord,
   module Enum,
   module Bounded,
+  module Functor,
+  module Monad,
 
   -- *** Numeric type classes
   module Num,
@@ -49,4 +51,5 @@ import Data.Array.Accelerate.Classes.Ord                            as Ord
 import Data.Array.Accelerate.Classes.RealFloat                      as RealFloat
 import Data.Array.Accelerate.Classes.RealFrac                       as RealFrac
 import Data.Array.Accelerate.Classes.ToFloating                     as ToFloating
-
+import Data.Array.Accelerate.Data.Functor                           as Functor
+import Data.Array.Accelerate.Data.Monad                             as Monad

--- a/src/Data/Array/Accelerate/Data/Complex.hs
+++ b/src/Data/Array/Accelerate/Data/Complex.hs
@@ -45,7 +45,6 @@ module Data.Array.Accelerate.Data.Complex (
 ) where
 
 import Data.Array.Accelerate.Classes
-import Data.Array.Accelerate.Data.Functor
 import Data.Array.Accelerate.Pattern
 import Data.Array.Accelerate.Prelude
 import Data.Array.Accelerate.Representation.Tag

--- a/src/Data/Array/Accelerate/Data/Either.hs
+++ b/src/Data/Array/Accelerate/Data/Either.hs
@@ -47,6 +47,7 @@ import Data.Array.Accelerate.Classes.Eq
 import Data.Array.Accelerate.Classes.Ord
 
 import Data.Array.Accelerate.Data.Functor
+import Data.Array.Accelerate.Data.Monad
 import Data.Array.Accelerate.Data.Monoid
 import Data.Array.Accelerate.Data.Semigroup
 
@@ -110,6 +111,10 @@ rights es = compact (map isRight es) (map fromRight es)
 
 instance Elt a => Functor (Either a) where
   fmap f = either Left_ (Right_ . f)
+
+instance Elt a => Monad (Either a) where
+  return = Right_
+  x >>= f = either Left_ f x
 
 instance (Eq a, Eq b) => Eq (Either a b) where
   (==) = match go

--- a/src/Data/Array/Accelerate/Data/Functor.hs
+++ b/src/Data/Array/Accelerate/Data/Functor.hs
@@ -10,7 +10,7 @@
 --
 -- A functor performs a uniform action over a parameterised type
 --
--- This is essentially the same as the standard Haskell 'Prelude.Functor' class,
+-- This is essentially the same as the standard Haskell 'Data.Functor' class,
 -- lifted to Accelerate 'Exp' terms.
 --
 -- @since 1.2.0.0

--- a/src/Data/Array/Accelerate/Data/Maybe.hs
+++ b/src/Data/Array/Accelerate/Data/Maybe.hs
@@ -47,6 +47,7 @@ import Data.Array.Accelerate.Classes.Eq
 import Data.Array.Accelerate.Classes.Ord
 
 import Data.Array.Accelerate.Data.Functor
+import Data.Array.Accelerate.Data.Monad
 import Data.Array.Accelerate.Data.Monoid
 import Data.Array.Accelerate.Data.Semigroup
 
@@ -105,6 +106,12 @@ instance Functor Maybe where
   fmap f = match \case
     Nothing_ -> Nothing_
     Just_ x  -> Just_ (f x)
+
+instance Monad Maybe where
+  return = Just_
+  (=<<) f = match \case
+    Nothing_ -> Nothing_
+    Just_ x -> f x
 
 instance Eq a => Eq (Maybe a) where
   (==) = match go

--- a/src/Data/Array/Accelerate/Data/Monad.hs
+++ b/src/Data/Array/Accelerate/Data/Monad.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE RebindableSyntax #-}
 -- |
--- Module      : Data.Array.Accelerate.Data.Functor
+-- Module      : Data.Array.Accelerate.Data.Monad
 -- Copyright   : [2018..2020] The Accelerate Team
 -- License     : BSD3
 --
@@ -8,12 +7,12 @@
 -- Stability   : experimental
 -- Portability : non-portable (GHC extensions)
 --
--- A functor performs a uniform action over a parameterised type
+-- A monad sequences actions over a parametrised type.
 --
--- This is essentially the same as the standard Haskell 'Prelude.Functor' class,
+-- This is essentially the same as the standard Haskell 'Control.Monad' class,
 -- lifted to Accelerate 'Exp' terms.
 --
--- @since 1.2.0.0
+-- @since 1.4.0.0
 --
 
 module Data.Array.Accelerate.Data.Monad (
@@ -30,11 +29,15 @@ import Data.Array.Accelerate.Smart
 import qualified Prelude as P
 
 
--- | The 'Functor' class is used for scalar types which can be mapped over.
--- Instances of 'Functor' should satisfy the following laws:
+-- | The 'Monad' class is used for scalar types which can be sequenced.
+-- Instances of 'Monad' should satisfy the following laws:
 --
--- > fmap id      == id
--- > fmap (f . g) == fmap f . fmap g
+-- [Left identity]  @'return' a '>>=' k  =  k a@
+-- [Right identity] @m '>>=' 'return'  =  m@
+-- [Associativity]  @m '>>=' (\\x -> k x '>>=' h)  =  (m '>>=' k) '>>=' h@
+-- 
+-- Furthermore, the 'Monad' and 'Functor' operations should relate as follows:
+-- * @'fmap' f xs  =  xs '>>=' 'return' . f@
 --
 class Functor m => Monad m where
   -- | Sequentially compose two actions, passing any value produced

--- a/src/Data/Array/Accelerate/Data/Monad.hs
+++ b/src/Data/Array/Accelerate/Data/Monad.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE RebindableSyntax #-}
+-- |
+-- Module      : Data.Array.Accelerate.Data.Functor
+-- Copyright   : [2018..2020] The Accelerate Team
+-- License     : BSD3
+--
+-- Maintainer  : Trevor L. McDonell <trevor.mcdonell@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+-- A functor performs a uniform action over a parameterised type
+--
+-- This is essentially the same as the standard Haskell 'Prelude.Functor' class,
+-- lifted to Accelerate 'Exp' terms.
+--
+-- @since 1.2.0.0
+--
+
+module Data.Array.Accelerate.Data.Monad (
+
+  Monad(..)
+
+) where
+
+import Data.Array.Accelerate.Data.Functor
+
+import Data.Array.Accelerate.Sugar.Elt
+import Data.Array.Accelerate.Smart
+
+import qualified Prelude as P
+
+
+-- | The 'Functor' class is used for scalar types which can be mapped over.
+-- Instances of 'Functor' should satisfy the following laws:
+--
+-- > fmap id      == id
+-- > fmap (f . g) == fmap f . fmap g
+--
+class Functor m => Monad m where
+  -- | Sequentially compose two actions, passing any value produced
+  -- by the first as an argument to the second.
+  --
+  -- \'@as '>>=' bs@\' can be understood as the @do@ expression
+  --
+  -- @
+  -- do a <- as
+  --    bs a
+  -- @
+  (>>=) :: (Elt a, Elt b, Elt (m a), Elt (m b)) => Exp (m a) -> (Exp a -> Exp (m b)) -> Exp (m b)
+  (>>=) = P.flip (=<<)
+
+  (=<<) :: (Elt a, Elt b, Elt (m a), Elt (m b)) => (Exp a -> Exp (m b)) -> Exp (m a) -> Exp (m b)
+  (=<<) = P.flip (>>=)
+
+  -- | Sequentially compose two actions, discarding any value produced
+  -- by the first, like sequencing operators (such as the semicolon)
+  -- in imperative languages.
+  --
+  -- \'@as '>>' bs@\' can be understood as the @do@ expression
+  --
+  -- @
+  -- do as
+  --    bs
+  -- @
+  (>>) :: (Elt a, Elt b, Elt (m a), Elt (m b)) => Exp (m a) -> Exp (m b) -> Exp (m b)
+  m >> k = m >>= \_ -> k
+  {-# INLINE (>>) #-}
+
+  -- | Inject a value into the monadic type.
+  return :: (Elt a, Elt (m a)) => Exp a -> Exp (m a)
+  return = pure
+
+  -- | Inject a value into the monadic type.
+  pure :: (Elt a, Elt (m a)) => Exp a -> Exp (m a)
+  pure = return
+
+  {-# MINIMAL ((>>=) | (=<<)), (return | pure) #-}


### PR DESCRIPTION
**Description**
Adds a Monad typeclass, and exports two modules (Functor and Either) which I was surprised to see unexported.

**Motivation and context**
While toying with a little Accelerate project, playing around with the pattern synonyms, I found myself implementing (>>=) for Maybe, and was surprised to see it not in Accelerate.

**How has this been tested?**
The Show instance looked reasonable.

**Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

