### PR TITLE
Add stubs for FFI functions to fix Haskell Language Server

### DIFF
--- a/src/Data/Array/Accelerate/Debug/Internal/Flags.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal/Flags.hs
@@ -161,6 +161,12 @@ clearFlags = mapM_ clearFlag
 -- notEnabled = error $ unlines [ "Data.Array.Accelerate: Debugging options are disabled."
 --                              , "Reinstall package 'accelerate' with '-fdebug' to enable them." ]
 
+-- FIXME: HLS requires stubs because it does not process the
+--        'addForeignFilePath' calls when evaluating Template Haskell
+--
+--        https://github.com/haskell/haskell-language-server/issues/365
+#ifndef __GHCIDE__
+
 -- Import the underlying flag variables. These are defined in the file
 -- cbits/flags.h as a bitfield and initialised at program initialisation.
 --
@@ -173,6 +179,19 @@ foreign import ccall "&__cmd_line_flags" __cmd_line_flags :: Ptr Word32
 --
 foreign import ccall "&__unfolding_use_threshold"   unfolding_use_threshold   :: Value  -- the magic cut-off figure for inlining
 foreign import ccall "&__max_simplifier_iterations" max_simplifier_iterations :: Value  -- maximum number of scalar simplification passes
+
+#else
+
+__cmd_line_flags :: Ptr Word32
+__cmd_line_flags = undefined
+
+unfolding_use_threshold :: Value
+unfolding_use_threshold = undefined
+
+max_simplifier_iterations :: Value
+max_simplifier_iterations = undefined
+
+#endif
 
 -- These @-f<blah>@ flags can be reversed with @-fno-<blah>@
 --

--- a/src/Data/Atomic.hs
+++ b/src/Data/Atomic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE MagicHash                #-}
 {-# LANGUAGE NoImplicitPrelude        #-}
@@ -49,6 +50,12 @@ newtype Atomic = Atomic ( Ptr Int64 )
 --   write a v
 --   return a
 
+-- FIXME: HLS requires stubs because it does not process the
+--        'addForeignFilePath' calls when evaluating Template Haskell
+--
+--        https://github.com/haskell/haskell-language-server/issues/365
+#ifndef __GHCIDE__
+
 -- | Get the current value.
 --
 foreign import ccall unsafe "atomic_read_64" read :: Atomic -> IO Int64
@@ -68,6 +75,25 @@ foreign import ccall unsafe "atomic_fetch_and_and_64" and :: Atomic -> Int64 -> 
 -- | Decrement the atomic value by the given amount. Return the old value.
 --
 foreign import ccall unsafe "atomic_fetch_and_sub_64" subtract :: Atomic -> Int64 -> IO Int64
+
+#else
+
+read :: Atomic -> IO Int64
+read = undefined
+
+write :: Atomic -> Int64 -> IO ()
+write = undefined
+
+add :: Atomic -> Int64 -> IO Int64
+add = undefined
+
+and :: Atomic -> Int64 -> IO Int64
+and = undefined
+
+subtract :: Atomic -> Int64 -> IO Int64
+subtract = undefined
+
+#endif
 
 -- SEE: [linking to .c files]
 --


### PR DESCRIPTION
**Description**
This add stubs for the functions imported from `cbits/` through the FFI as suggested in https://github.com/haskell/haskell-language-server/issues/365#issuecomment-782865927. This prevents HLS from showing errors in the `Data.Array.Accelerate.Pattern.*` modules, which would otherwise cause HLS to not work with any part of Accelerate that either directly or indirectly imported these modules.

**Motivation and context**
This allows HLS to be used with Accelerate. Similar changes might be needed for accelerate-llvm.

**How has this been tested?**
By briefly verifying that HLS no longer reports any errors or diagnostics for the entire project and that auto completion works again in the `Data.Array.Accelerate` module. The `haskell-language-server` binary now also runs without any errors.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

