### PR TITLE
Remove dependency on lens

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -300,7 +300,7 @@ library
         , hashable                      >= 1.1
         , hashtables                    >= 1.2.3
         , hedgehog                      >= 0.5
-        , lens                          >= 4.0
+        , microlens                     >= 0.4
         , mtl                           >= 2.0
         , prettyprinter                 >= 1.2
         , prettyprinter-ansi-terminal   >= 1.0

--- a/src/Data/Array/Accelerate/Prelude.hs
+++ b/src/Data/Array/Accelerate/Prelude.hs
@@ -137,7 +137,7 @@ import Data.Array.Accelerate.Classes.Ord
 
 import Data.Array.Accelerate.Data.Bits
 
-import Control.Lens                                                 ( Lens', (&), (^.), (.~), (+~), (-~), lens, over )
+import Lens.Micro                                                   ( Lens', (&), (^.), (.~), (+~), (-~), lens, over )
 import Prelude                                                      ( (.), ($), Maybe(..), const, id, flip )
 
 

--- a/src/Data/Array/Accelerate/Test/NoFib/Prelude/SIMD.hs
+++ b/src/Data/Array/Accelerate/Test/NoFib/Prelude/SIMD.hs
@@ -20,7 +20,7 @@ module Data.Array.Accelerate.Test.NoFib.Prelude.SIMD (
 
 ) where
 
-import Control.Lens                                                 ( view, _1, _2, _3, _4 )
+import Lens.Micro                                                 ( view, _1, _2, _3, _4 )
 import Prelude                                                      as P
 
 import Data.Array.Accelerate                                        as A

--- a/src/Data/Array/Accelerate/Test/NoFib/Prelude/SIMD.hs
+++ b/src/Data/Array/Accelerate/Test/NoFib/Prelude/SIMD.hs
@@ -20,7 +20,8 @@ module Data.Array.Accelerate.Test.NoFib.Prelude.SIMD (
 
 ) where
 
-import Lens.Micro                                                 ( view, _1, _2, _3, _4 )
+import Lens.Micro                                                 ( _1, _2, _3, _4 )
+import Lens.Micro.Extras                                          ( view )
 import Prelude                                                      as P
 
 import Data.Array.Accelerate                                        as A

--- a/src/Data/Array/Accelerate/Trafo/Fusion.hs
+++ b/src/Data/Array/Accelerate/Trafo/Fusion.hs
@@ -67,7 +67,7 @@ import System.IO.Unsafe -- for debugging
 #endif
 
 import Data.Function
-import Control.Lens                                                 ( over, mapped, _2 )
+import Lens.Micro                                                 ( over, mapped, _2 )
 import Prelude                                                      hiding ( exp, until )
 
 

--- a/src/Data/Array/Accelerate/Trafo/Sharing.hs
+++ b/src/Data/Array/Accelerate/Trafo/Sharing.hs
@@ -71,7 +71,7 @@ import qualified Data.Array.Accelerate.Representation.Stencil       as R
 import qualified Data.Array.Accelerate.Sugar.Array                  as Sugar
 
 import Control.Applicative                                          hiding ( Const )
-import Control.Lens                                                 ( over, mapped, _1, _2 )
+import Lens.Micro                                                 ( over, mapped, _1, _2 )
 import Control.Monad.Fix
 import Data.Function                                                ( on )
 import Data.Hashable

--- a/src/Data/Array/Accelerate/Trafo/Simplify.hs
+++ b/src/Data/Array/Accelerate/Trafo/Simplify.hs
@@ -51,7 +51,7 @@ import qualified Data.Array.Accelerate.Debug.Internal.Flags         as Debug
 import qualified Data.Array.Accelerate.Debug.Internal.Trace         as Debug
 
 import Control.Applicative                                          hiding ( Const )
-import Control.Lens                                                 hiding ( Const, ix )
+import Lens.Micro                                                   hiding ( ix )
 import Data.List                                                    ( partition )
 import Data.Maybe
 import Data.Monoid


### PR DESCRIPTION
This replaces lens with microlens, probably decreasing compilation time significantly at near-zero cost. Pending CI, but it builds locally