### PR TITLE
Add errors and assertions to Acc computations

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -329,6 +329,8 @@ library
         Data.Array.Accelerate.Data.Maybe
         Data.Array.Accelerate.Data.Monoid
         Data.Array.Accelerate.Data.Ratio
+        Data.Array.Accelerate.Debug.Assert
+        Data.Array.Accelerate.Debug.Error
         Data.Array.Accelerate.Debug.Trace
         Data.Array.Accelerate.Unsafe
 

--- a/src/Data/Array/Accelerate/Analysis/Hash.hs
+++ b/src/Data/Array/Accelerate/Analysis/Hash.hs
@@ -170,6 +170,7 @@ encodePreOpenAcc options encodeAcc pacc =
     Apair a1 a2                     -> intHost $(hashQ "Apair")       <> travA a1 <> travA a2
     Anil                            -> intHost $(hashQ "Anil")
     Atrace (Message _ _ msg) as bs  -> intHost $(hashQ "Atrace")      <> intHost (Hashable.hash msg) <> travA as <> travA bs
+    Aerror r (Message _ _ msg) as   -> intHost $(hashQ "Aerror")      <> encodeArraysType r <> intHost (Hashable.hash msg) <> travA as
     Apply _ f a                     -> intHost $(hashQ "Apply")       <> travAF f <> travA a
     Aforeign _ _ f a                -> intHost $(hashQ "Aforeign")    <> travAF f <> travA a
     Use repr a                      -> intHost $(hashQ "Use")         <> encodeArrayType repr <> deep (encodeArray a)

--- a/src/Data/Array/Accelerate/Debug/Assert.hs
+++ b/src/Data/Array/Accelerate/Debug/Assert.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE TypeFamilies        #-}
+-- |
+-- Module      : Data.Array.Accelerate.Debug.Assert
+-- Copyright   : [2008..2020] The Accelerate Team
+-- License     : BSD3
+--
+-- Maintainer  : Trevor L. McDonell <trevor.mcdonell@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+-- Functions for checking properties or invariants
+-- of a program.
+--
+-- @since 1.4.0.0
+--
+
+module Data.Array.Accelerate.Debug.Assert (
+
+  -- * Assertions
+  -- $assertions
+  --
+  assert, Assertion,
+  expEqual, AssertEqual,
+  arraysEqual, AssertArraysEqual,
+
+) where
+
+import qualified Data.Array.Accelerate                              as A
+import Data.Array.Accelerate.Smart
+import Data.Array.Accelerate.Sugar.Array                            as S
+import Data.Array.Accelerate.Sugar.Elt
+import qualified Data.Array.Accelerate.Representation.Array         as R
+import qualified Data.Array.Accelerate.Representation.Shape         as R
+
+
+-- $assertions
+--
+-- The 'assert' function verifies whether a predicate holds and will stop
+-- the execution of the array computation if the assertion does not hold.
+-- It will then also print the given error message to the console.
+--
+-- The predicate can be passed as a boolean expression ('Exp Bool'), but we
+-- have specialized assertions for array equivalence ('arraysEqual') and
+-- scalar equivalence ('expEqual').
+--
+
+-- Verifies whether the predicate holds, before the computation can continue
+-- with the result of the last argument. If the assertion does not hold,
+-- it will stop the array computation and print the error message.
+--
+assert :: forall a bs. (Assertion a, Arrays bs) => String -> a -> Acc bs -> Acc bs
+assert text assertion result
+  = A.acond (assertionCondition assertion) result
+  $ Acc
+  $ SmartAcc
+  $ Aerror (S.arraysR @bs)
+           (assertionMessage assertion $ "Assertion failed: " ++ text)
+           arg
+  where
+    Acc arg = assertionArg assertion
+
+class Arrays (AssertionArg a) => Assertion a where
+  type AssertionArg a
+
+  assertionArg :: a -> Acc (AssertionArg a)
+  assertionMessage :: a -> String -> Message (ArraysR (AssertionArg a))
+  assertionCondition :: a -> Exp Bool
+
+instance Assertion (Exp Bool) where
+  type AssertionArg (Exp Bool) = ()
+
+  assertionArg _ = Acc (SmartAcc Anil)
+  assertionMessage _ = Message (\_ -> "") (Just [|| \_ -> "" ||])
+  assertionCondition = id
+
+data AssertEqual e = AssertEqual (Exp e) (Exp e)
+
+expEqual :: Exp e -> Exp e -> AssertEqual e
+expEqual = AssertEqual
+
+instance (Elt e, A.Eq e, Show e) => Assertion (AssertEqual e) where
+  type AssertionArg (AssertEqual e) = Scalar (e, e)
+
+  assertionArg (AssertEqual a b) = A.unit (A.T2 a b)
+  assertionMessage _ = Message  (\e -> let (a, b) = toElt @(e, e) (R.indexArray (R.ArrayR R.dim0 (eltR @(e, e))) e ()) in show a ++ " does not equal " ++ show b)
+                       (Just [||(\e -> let (a, b) = toElt @(e, e) (R.indexArray (R.ArrayR R.dim0 (eltR @(e, e))) e ()) in show a ++ " does not equal " ++ show b) ||])
+  assertionCondition (AssertEqual a b) = a A.== b
+
+data AssertArraysEqual as = AssertArraysEqual (Acc as) (Acc as)
+
+arraysEqual :: Acc as -> Acc as -> AssertArraysEqual as
+arraysEqual = AssertArraysEqual
+
+instance (Show sh, Show e, A.Shape sh, Elt e, A.Eq sh, A.Eq e) => Assertion (AssertArraysEqual (S.Array sh e)) where
+  type AssertionArg (AssertArraysEqual (S.Array sh e)) = (S.Array sh e, S.Array sh e)
+
+  assertionArg (AssertArraysEqual xs ys) = A.T2 xs ys
+  assertionMessage _ = Message  (\(((), xs), ys) -> "\n" ++ show (toArr @(S.Array sh e) xs) ++ "\ndoes not equal\n" ++ show (toArr @(S.Array sh e) ys))
+                       (Just [||(\(((), xs), ys) -> "\n" ++ show (toArr @(S.Array sh e) xs) ++ "\ndoes not equal\n" ++ show (toArr @(S.Array sh e) ys)) ||])
+  assertionCondition (AssertArraysEqual xs ys) = (A.shape xs A.== A.shape ys) A.&& A.the (A.all id $ A.reshape (A.I1 $ A.size xs) $ A.zipWith (A.==) xs ys)

--- a/src/Data/Array/Accelerate/Debug/Error.hs
+++ b/src/Data/Array/Accelerate/Debug/Error.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell     #-}
+{-# LANGUAGE TypeApplications    #-}
+-- |
+-- Module      : Data.Array.Accelerate.Debug.Error
+-- Copyright   : [2008..2020] The Accelerate Team
+-- License     : BSD3
+--
+-- Maintainer  : Trevor L. McDonell <trevor.mcdonell@gmail.com>
+-- Stability   : experimental
+-- Portability : non-portable (GHC extensions)
+--
+-- Functions for checking properties or invariants
+-- of a program.
+--
+-- @since 1.4.0.0
+--
+
+module Data.Array.Accelerate.Debug.Error (
+
+  -- * Throwing errors
+  -- $errors
+  --
+  aerror, aerrorArray, aerrorExp
+
+) where
+
+import Data.Array.Accelerate.Language
+import Data.Array.Accelerate.Smart
+import Data.Array.Accelerate.Sugar.Array                            as S
+import Data.Array.Accelerate.Sugar.Elt
+import qualified Data.Array.Accelerate.Representation.Array         as R
+import qualified Data.Array.Accelerate.Representation.Shape         as R
+
+
+-- $errors
+--
+-- The 'aerror', 'aerrorArray', and 'aerrorExp' functions abort the execution
+-- of the array program and print errors to an output stream. They are intended
+-- for stopping the program when the program is in some invalid state, which
+-- was expected to be unreachable.
+--
+-- Besides printing a given error message, it can also print the contents of an
+-- array (with 'aerrorArray') or print some scalar value ('aerrorExp').
+--
+
+-- | Stops execution of the array computation and outputs the error message to
+-- the console.
+--
+aerror :: forall a. Arrays a => String -> Acc a
+aerror message
+  = Acc
+  $ SmartAcc
+  $ Aerror (S.arraysR @a)
+           (Message (\_ -> "") (Just [|| \_ -> "" ||]) message)
+           (SmartAcc Anil :: SmartAcc ())
+
+-- | Outputs the trace message and the array(s) from the second argument to
+-- the console, before the 'Acc' computation proceeds with the result of
+-- the third argument.
+--
+aerrorArray :: forall a b. (Arrays a, Arrays b, Show a) => String -> Acc a -> Acc b
+aerrorArray message (Acc inspect)
+  = Acc
+  $ SmartAcc
+  $ Aerror (S.arraysR @b)
+           (Message (show . toArr @a)
+           (Just [|| show . toArr @a ||]) message) inspect
+
+-- | Outputs the trace message and a scalar value to the console, before
+-- the 'Acc' computation proceeds with the result of the third argument.
+--
+aerrorExp :: forall e a. (Elt e, Show e, Arrays a) => String -> Exp e -> Acc a
+aerrorExp message value =
+  let Acc inspect = unit value
+   in Acc
+    $ SmartAcc
+    $ Aerror (S.arraysR @a)
+             (Message (\a -> show (toElt @e (R.indexArray (R.ArrayR R.dim0 (eltR @e)) a ())))
+             (Just [|| \a -> show (toElt @e (R.indexArray (R.ArrayR R.dim0 (eltR @e)) a ())) ||]) message) inspect
+

--- a/src/Data/Array/Accelerate/Pretty/Graphviz.hs
+++ b/src/Data/Array/Accelerate/Pretty/Graphviz.hs
@@ -230,6 +230,7 @@ prettyDelayedOpenAcc detail ctx aenv atop@(Manifest pacc) =
 
     Anil                            -> "()"             .$ []
     Atrace (Message _ _ msg) as bs  -> "atrace"         .$ [ return $ PDoc (fromString msg) [], ppA as, ppA bs ]
+    Aerror _ (Message _ _ msg) as   -> "aerror"         .$ [ return $ PDoc (fromString msg) [], ppA as ]
     Use repr arr                    -> "use"            .$ [ return $ PDoc (prettyArray repr arr) [] ]
     Unit _ e                        -> "unit"           .$ [ ppE e ]
     Generate _ sh f                 -> "generate"       .$ [ ppE sh, ppF f ]

--- a/src/Data/Array/Accelerate/Pretty/Print.hs
+++ b/src/Data/Array/Accelerate/Pretty/Print.hs
@@ -194,6 +194,7 @@ prettyPreOpenAcc config ctx prettyAcc extractAcc aenv pacc =
 
 
     Atrace (Message _ _ msg) as bs  -> ppN "atrace"      .$ [ fromString (show msg), ppA as, ppA bs ]
+    Aerror _ (Message _ _ msg) as   -> ppN "aerror"      .$ [ fromString (show msg), ppA as ]
     Aforeign _ ff _ a               -> ppN "aforeign"    .$ [ pretty (strForeign ff), ppA a ]
     Awhile p f a                    -> ppN "awhile"      .$ [ ppAF p, ppAF f, ppA a ]
     Use repr arr                    -> ppN "use"         .$ [ prettyArray repr arr ]

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -359,6 +359,11 @@ data PreSmartAcc acc exp as where
                 -> acc arrs2
                 -> PreSmartAcc acc exp arrs2
 
+  Aerror        :: ArraysR arrs2
+                -> Message arrs1
+                -> acc arrs1
+                -> PreSmartAcc acc exp arrs2
+
   Use           :: ArrayR (Array sh e)
                 -> Array sh e
                 -> PreSmartAcc acc exp (Array sh e)
@@ -805,6 +810,7 @@ instance HasArraysR acc => HasArraysR (PreSmartAcc acc exp) where
                                    PairIdxRight -> t2
     Aprj _ _                  -> error "Ejector seat? You're joking!"
     Atrace _ _ a              -> arraysR a
+    Aerror repr _ _           -> repr
     Use repr _                -> TupRsingle repr
     Unit tp _                 -> TupRsingle $ ArrayR ShapeRz $ tp
     Generate repr _ _         -> TupRsingle repr
@@ -1315,6 +1321,7 @@ showPreAccOp Apair{}               = "Apair"
 showPreAccOp Anil{}                = "Anil"
 showPreAccOp Aprj{}                = "Aprj"
 showPreAccOp Atrace{}              = "Atrace"
+showPreAccOp Aerror{}              = "Aerror"
 showPreAccOp Unit{}                = "Unit"
 showPreAccOp Generate{}            = "Generate"
 showPreAccOp Reshape{}             = "Reshape"

--- a/src/Data/Array/Accelerate/Trafo/Fusion.hs
+++ b/src/Data/Array/Accelerate/Trafo/Fusion.hs
@@ -178,6 +178,7 @@ manifest config (OpenAcc pacc) =
     Apair a1 a2             -> Apair (manifest config a1) (manifest config a2)
     Anil                    -> Anil
     Atrace msg a1 a2        -> Atrace msg (manifest config a1) (manifest config a2)
+    Aerror repr msg a1      -> Aerror repr msg (manifest config a1)
     Apply repr f a          -> apply repr (cvtAF f) (manifest config a)
     Aforeign repr ff f a    -> Aforeign repr ff (cvtAF f) (manifest config a)
 
@@ -370,6 +371,7 @@ embedPreOpenAcc config matchAcc embedAcc elimAcc pacc
     Awhile p f a        -> done $ Awhile (cvtAF p) (cvtAF f) (cvtA a)
     Apair a1 a2         -> done $ Apair (cvtA a1) (cvtA a2)
     Atrace msg a1 a2    -> done $ Atrace msg (cvtA a1) (cvtA a2)
+    Aerror repr msg a1  -> done $ Aerror repr msg (cvtA a1)
     Aforeign aR ff f a  -> done $ Aforeign aR ff (cvtAF f) (cvtA a)
     -- Collect s           -> collectD s
 
@@ -1548,6 +1550,7 @@ aletD' embedAcc elimAcc (LeftHandSideSingle ArrayR{}) (Embed env1 cc1) (Embed en
         Acond p at ae           -> Acond (cvtE p) (cvtA at) (cvtA ae)
         Anil                    -> Anil
         Atrace msg a b          -> Atrace msg (cvtA a) (cvtA b)
+        Aerror repr msg a       -> Aerror repr msg (cvtA a)
         Apair a1 a2             -> Apair (cvtA a1) (cvtA a2)
         Awhile p f a            -> Awhile (cvtAF p) (cvtAF f) (cvtA a)
         Apply repr f a          -> Apply repr (cvtAF f) (cvtA a)

--- a/src/Data/Array/Accelerate/Trafo/LetSplit.hs
+++ b/src/Data/Array/Accelerate/Trafo/LetSplit.hs
@@ -38,6 +38,7 @@ convertPreOpenAcc = \case
   Apair a1 a2                     -> Apair (convertAcc a1) (convertAcc a2)
   Anil                            -> Anil
   Atrace msg as bs                -> Atrace msg (convertAcc as) (convertAcc bs)
+  Aerror repr msg as              -> Aerror repr msg (convertAcc as)
   Apply repr f a                  -> Apply repr (convertAfun f) (convertAcc a)
   Aforeign repr asm f a           -> Aforeign repr asm (convertAfun f) (convertAcc a)
   Acond e a1 a2                   -> Acond e (convertAcc a1) (convertAcc a2)

--- a/src/Data/Array/Accelerate/Trafo/Shrink.hs
+++ b/src/Data/Array/Accelerate/Trafo/Shrink.hs
@@ -544,6 +544,7 @@ usesOfPreAcc withShape countAcc idx = count
       Apair a1 a2                -> countA a1 + countA a2
       Anil                       -> 0
       Atrace _ a1 a2             -> countA a1 + countA a2
+      Aerror _ _ a1              -> countA a1
       Apply _ f a                -> countAF f idx + countA a
       Aforeign _ _ _ a           -> countA a
       Acond p t e                -> countE p + countA t + countA e

--- a/src/Data/Array/Accelerate/Trafo/Substitution.hs
+++ b/src/Data/Array/Accelerate/Trafo/Substitution.hs
@@ -681,6 +681,7 @@ rebuildPreOpenAcc k av acc =
     Apair as bs               -> Apair           <$> k av as <*> k av bs
     Anil                      -> pure Anil
     Atrace msg as bs          -> Atrace msg      <$> k av as <*> k av bs
+    Aerror repr msg as        -> Aerror repr msg <$> k av as
     Apply repr f a            -> Apply repr      <$> rebuildAfun k av f <*> k av a
     Acond p t e               -> Acond           <$> rebuildOpenExp (pure . IE) av' p <*> k av t <*> k av e
     Awhile p f a              -> Awhile          <$> rebuildAfun k av p <*> rebuildAfun k av f <*> k av a


### PR DESCRIPTION
**Description**
This pull requests adds throwing functions, similar to `error` from the Prelude, and assertions to our Acc language.

I added three functions to throw an error:
- `aerror :: Arrays a => String -> Acc a`: given a string, throws an error containing that string
- `aerrorArray :: (Arrays a, Arrays b, Show a) => String -> Acc a -> Acc b`: takes a string and an array, similar to `atraceArray`
- `aerrorExp :: (Elt e, Show e, Arrays a) => String -> Exp e -> Acc a`: takes a string and an expression, similar to `atraceExp`

Assertions can be written using `assert :: (Assertion a, Arrays bs) => String -> a -> Acc bs -> Acc bs`. I'm not sure about its interface yet, so feel free to share some thoughts about that :)
- Name: We might in the future also add expression-level assertions. It would thus make sense to use `aassert` for array level assertions, similar to how `acond`, `awhile` and `atrace` are array-level variants of functionalities which are or may be (in the future) available on expressions. Though I didn't like how `aassert` looked. Hence my idea was to use `assert` here, and in the future we could use `expect` for expression-level assertions (note that assert still starts with an a and expect starts with the e of expression, nice coincidence).
- Predicate: The assertion of course consists of some predicate / condition. My initial thought was to use an `Exp Bool`, but I also wanted to give better error messages than just saying that the assertion failed. For instance, when asserting that two values are equal I'd like to show those two values. This could be done by making multiple assertion functions, inspecting the expression and detecting several patterns, or having a type class ranging over types of assertions. I didn't really like the first option, that resulted in signatures like `assertArraysEqual :: (Shape sh, Eq sh, Elt a, Eq a, Arrays bs) => String -> Acc (Array sh a) -> Acc (Array sh a) -> Acc bs -> Acc bs`. With the second approach it would be difficult to detect patterns like array equivalence, as that consists not only of Exp code but also Acc code. I chose the latter. Currently the instances of the type class are `Exp Bool` (which has no further message), `data AssertArraysEqual as = AssertArraysEqual (Acc as) (Acc as)` which asserts that arrays are equal, and `data AssertEqual e = AssertEqual (Exp e) (Exp e)`.
- Array equivalence is currently limited to a single array, we could extend that to tuples of arrays.

**Motivation and context**
These functions should make it easier for users to detect problems in their code. It is also possible to use these functions for parts of the algorithm which haven't been implemented, similar to `undefined` from the Prelude, as the program now still compiles and will only crash when such part is actually used.

**How has this been tested?**
Just a quick test, no automated tests yet.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

I still need to make the accompanying change in accelerate-llvm.

