### PR TITLE
Improve stability by reducing dependency on dollar

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -426,6 +426,7 @@ library
         Data.Array.Accelerate.Trafo.Shrink
         Data.Array.Accelerate.Trafo.Simplify
         Data.Array.Accelerate.Trafo.Var
+        Data.Array.Accelerate.Uncurrency
         Data.Atomic
 
         -- Data.Array.Accelerate.Array.Lifted

--- a/src/Data/Array/Accelerate/AST.hs
+++ b/src/Data/Array/Accelerate/AST.hs
@@ -808,10 +808,10 @@ expType = \case
   Foreign tR _ _ _             -> tR
   Pair e1 e2                   -> TupRpair (expType e1) (expType e2)
   Nil                          -> TupRunit
-  VecPack   vecR _             -> TupRsingle $ VectorScalarType $ vecRvector vecR
+  VecPack   vecR _             -> TupRsingle $ VectorScalarType `id` vecRvector vecR
   VecUnpack vecR _             -> vecRtuple vecR
-  IndexSlice si _ _            -> shapeType $ sliceShapeR si
-  IndexFull  si _ _            -> shapeType $ sliceDomainR si
+  IndexSlice si _ _            -> shapeType `id` sliceShapeR si
+  IndexFull  si _ _            -> shapeType `id` sliceDomainR si
   ToIndex{}                    -> TupRsingle scalarTypeInt
   FromIndex shr _ _            -> shapeType shr
   Case _ ((_,e):_) _           -> expType e
@@ -821,11 +821,11 @@ expType = \case
   While _ (Lam lhs _) _        -> lhsToTupR lhs
   While{}                      -> error "What's the matter, you're running in the shadows"
   Const tR _                   -> TupRsingle tR
-  PrimConst c                  -> TupRsingle $ SingleScalarType $ primConstType c
-  PrimApp f _                  -> snd $ primFunType f
+  PrimConst c                  -> TupRsingle $ SingleScalarType `id` primConstType c
+  PrimApp f _                  -> snd `id` primFunType f
   Index (Var repr _) _         -> arrayRtype repr
   LinearIndex (Var repr _) _   -> arrayRtype repr
-  Shape (Var repr _)           -> shapeType $ arrayRshape repr
+  Shape (Var repr _)           -> shapeType `id` arrayRshape repr
   ShapeSize{}                  -> TupRsingle scalarTypeInt
   Undef tR                     -> TupRsingle tR
   Coerce _ tR _                -> TupRsingle tR
@@ -837,7 +837,7 @@ primConstType = \case
   PrimPi       t -> floating t
   where
     bounded :: BoundedType a -> SingleType a
-    bounded (IntegralBoundedType t) = NumSingleType $ IntegralNumType t
+    bounded (IntegralBoundedType t) = NumSingleType `id` IntegralNumType t
 
     floating :: FloatingType t -> SingleType t
     floating = NumSingleType . FloatingNumType
@@ -845,26 +845,26 @@ primConstType = \case
 primFunType :: PrimFun (a -> b) -> (TypeR a, TypeR b)
 primFunType = \case
   -- Num
-  PrimAdd t                 -> binary' $ num t
-  PrimSub t                 -> binary' $ num t
-  PrimMul t                 -> binary' $ num t
-  PrimNeg t                 -> unary'  $ num t
-  PrimAbs t                 -> unary'  $ num t
-  PrimSig t                 -> unary'  $ num t
+  PrimAdd t                 -> binary' `id` num t
+  PrimSub t                 -> binary' `id` num t
+  PrimMul t                 -> binary' `id` num t
+  PrimNeg t                 -> unary'  `id` num t
+  PrimAbs t                 -> unary'  `id` num t
+  PrimSig t                 -> unary'  `id` num t
 
   -- Integral
-  PrimQuot t                -> binary' $ integral t
-  PrimRem  t                -> binary' $ integral t
+  PrimQuot t                -> binary' `id` integral t
+  PrimRem  t                -> binary' `id` integral t
   PrimQuotRem t             -> unary' $ integral t `TupRpair` integral t
-  PrimIDiv t                -> binary' $ integral t
-  PrimMod  t                -> binary' $ integral t
+  PrimIDiv t                -> binary' `id` integral t
+  PrimMod  t                -> binary' `id` integral t
   PrimDivMod t              -> unary' $ integral t `TupRpair` integral t
 
   -- Bits & FiniteBits
-  PrimBAnd t                -> binary' $ integral t
-  PrimBOr t                 -> binary' $ integral t
-  PrimBXor t                -> binary' $ integral t
-  PrimBNot t                -> unary' $ integral t
+  PrimBAnd t                -> binary' `id` integral t
+  PrimBOr t                 -> binary' `id` integral t
+  PrimBXor t                -> binary' `id` integral t
+  PrimBNot t                -> unary' `id` integral t
   PrimBShiftL t             -> (integral t `TupRpair` int, integral t)
   PrimBShiftR t             -> (integral t `TupRpair` int, integral t)
   PrimBRotateL t            -> (integral t `TupRpair` int, integral t)
@@ -874,25 +874,25 @@ primFunType = \case
   PrimCountTrailingZeros t  -> unary (integral t) int
 
   -- Fractional, Floating
-  PrimFDiv t                -> binary' $ floating t
-  PrimRecip t               -> unary'  $ floating t
-  PrimSin t                 -> unary'  $ floating t
-  PrimCos t                 -> unary'  $ floating t
-  PrimTan t                 -> unary'  $ floating t
-  PrimAsin t                -> unary'  $ floating t
-  PrimAcos t                -> unary'  $ floating t
-  PrimAtan t                -> unary'  $ floating t
-  PrimSinh t                -> unary'  $ floating t
-  PrimCosh t                -> unary'  $ floating t
-  PrimTanh t                -> unary'  $ floating t
-  PrimAsinh t               -> unary'  $ floating t
-  PrimAcosh t               -> unary'  $ floating t
-  PrimAtanh t               -> unary'  $ floating t
-  PrimExpFloating t         -> unary'  $ floating t
-  PrimSqrt t                -> unary'  $ floating t
-  PrimLog t                 -> unary'  $ floating t
-  PrimFPow t                -> binary' $ floating t
-  PrimLogBase t             -> binary' $ floating t
+  PrimFDiv t                -> binary' `id` floating t
+  PrimRecip t               -> unary'  `id` floating t
+  PrimSin t                 -> unary'  `id` floating t
+  PrimCos t                 -> unary'  `id` floating t
+  PrimTan t                 -> unary'  `id` floating t
+  PrimAsin t                -> unary'  `id` floating t
+  PrimAcos t                -> unary'  `id` floating t
+  PrimAtan t                -> unary'  `id` floating t
+  PrimSinh t                -> unary'  `id` floating t
+  PrimCosh t                -> unary'  `id` floating t
+  PrimTanh t                -> unary'  `id` floating t
+  PrimAsinh t               -> unary'  `id` floating t
+  PrimAcosh t               -> unary'  `id` floating t
+  PrimAtanh t               -> unary'  `id` floating t
+  PrimExpFloating t         -> unary'  `id` floating t
+  PrimSqrt t                -> unary'  `id` floating t
+  PrimLog t                 -> unary'  `id` floating t
+  PrimFPow t                -> binary' `id` floating t
+  PrimLogBase t             -> binary' `id` floating t
 
   -- RealFrac
   PrimTruncate a b          -> unary (floating a) (integral b)
@@ -901,7 +901,7 @@ primFunType = \case
   PrimCeiling a b           -> unary (floating a) (integral b)
 
   -- RealFloat
-  PrimAtan2 t               -> binary' $ floating t
+  PrimAtan2 t               -> binary' `id` floating t
   PrimIsNaN t               -> unary (floating t) bool
   PrimIsInfinite t          -> unary (floating t) bool
 
@@ -912,8 +912,8 @@ primFunType = \case
   PrimGtEq t                -> compare' t
   PrimEq t                  -> compare' t
   PrimNEq t                 -> compare' t
-  PrimMax t                 -> binary' $ single t
-  PrimMin t                 -> binary' $ single t
+  PrimMax t                 -> binary' `id` single t
+  PrimMin t                 -> binary' `id` single t
 
   -- Logical
   PrimLAnd                  -> binary' bool
@@ -1014,13 +1014,13 @@ rnfPreOpenAcc rnfA pacc =
     Stencil sr tp f b a       ->
       let
         TupRsingle (ArrayR shr _) = arraysR a
-        repr                      = ArrayR shr $ stencilEltR sr
+        repr                      = ArrayR shr `id` stencilEltR sr
       in rnfStencilR sr `seq` rnfTupR rnfScalarType tp `seq` rnfF f `seq` rnfB repr b  `seq` rnfA a
     Stencil2 sr1 sr2 tp f b1 a1 b2 a2 ->
       let
         TupRsingle (ArrayR shr _) = arraysR a1
-        repr1 = ArrayR shr $ stencilEltR sr1
-        repr2 = ArrayR shr $ stencilEltR sr2
+        repr1 = ArrayR shr `id` stencilEltR sr1
+        repr2 = ArrayR shr `id` stencilEltR sr2
       in rnfStencilR sr1 `seq` rnfStencilR sr2 `seq` rnfTupR rnfScalarType tp `seq` rnfF f `seq` rnfB repr1 b1 `seq` rnfB repr2 b2 `seq` rnfA a1 `seq` rnfA a2
 
 rnfArrayVar :: ArrayVar aenv a -> ()
@@ -1221,12 +1221,12 @@ liftPreOpenAcc liftA pacc =
     Backpermute shr sh p a    -> [|| Backpermute $$(liftShapeR shr) $$(liftE sh) $$(liftF p) $$(liftA a) ||]
     Stencil sr tp f b a       ->
       let TupRsingle (ArrayR shr _) = arraysR a
-          repr = ArrayR shr $ stencilEltR sr
+          repr = ArrayR shr `id` stencilEltR sr
        in [|| Stencil $$(liftStencilR sr) $$(liftTypeR tp) $$(liftF f) $$(liftB repr b) $$(liftA a) ||]
     Stencil2 sr1 sr2 tp f b1 a1 b2 a2 ->
       let TupRsingle (ArrayR shr _) = arraysR a1
-          repr1 = ArrayR shr $ stencilEltR sr1
-          repr2 = ArrayR shr $ stencilEltR sr2
+          repr1 = ArrayR shr `id` stencilEltR sr1
+          repr2 = ArrayR shr `id` stencilEltR sr2
        in [|| Stencil2 $$(liftStencilR sr1) $$(liftStencilR sr2) $$(liftTypeR tp) $$(liftF f) $$(liftB repr1 b1) $$(liftA a1) $$(liftB repr2 b2) $$(liftA a2) ||]
 
 
@@ -1247,11 +1247,11 @@ liftMessage aR (Message _ fmt msg) =
       -- back to displaying in representation format
       fmtR :: ArraysR arrs' -> Q (TExp (arrs' -> String))
       fmtR TupRunit                         = [|| \() -> "()" ||]
-      fmtR (TupRsingle (ArrayR ShapeRz eR)) = [|| \as -> showElt $$(liftTypeR eR) $ linearIndexArray $$(liftTypeR eR) as 0 ||]
+      fmtR (TupRsingle (ArrayR ShapeRz eR)) = [|| \as -> showElt $$(liftTypeR eR) `id` linearIndexArray $$(liftTypeR eR) as 0 ||]
       fmtR (TupRsingle (ArrayR shR eR))     = [|| \as -> showArray (showsElt $$(liftTypeR eR)) (ArrayR $$(liftShapeR shR) $$(liftTypeR eR)) as ||]
       fmtR aR'                              = [|| \as -> showArrays $$(liftArraysR aR') as ||]
   in
-  [|| Message $$(fromMaybe (fmtR aR) fmt) Nothing $$(TH.unsafeTExpCoerce $ return $ TH.LitE $ TH.StringL msg) ||]
+  [|| Message $$(fromMaybe (fmtR aR) fmt) Nothing $$(TH.unsafeTExpCoerce $ return $ TH.LitE `id` TH.StringL msg) ||]
 
 liftMaybe :: (a -> Q (TExp a)) -> Maybe a -> Q (TExp (Maybe a))
 liftMaybe _ Nothing  = [|| Nothing ||]

--- a/src/Data/Array/Accelerate/Async.hs
+++ b/src/Data/Array/Accelerate/Async.hs
@@ -91,13 +91,13 @@ cancel (Async tid _) = throwTo tid ThreadKilled
 --
 {-# INLINE rawForkIO #-}
 rawForkIO :: IO () -> IO ThreadId
-rawForkIO action = IO $ \s ->
+rawForkIO action = IO `id` \s ->
   case fork# action s of
     (# s', tid #) -> (# s', ThreadId tid #)
 
 {-# INLINE rawForkOn #-}
 rawForkOn :: Int -> IO () -> IO ThreadId
-rawForkOn (I# cpu) action = IO $ \s ->
+rawForkOn (I# cpu) action = IO `id` \s ->
   case forkOn# cpu action s of
     (# s', tid #) -> (# s', ThreadId tid #)
 

--- a/src/Data/Array/Accelerate/Error.hs
+++ b/src/Data/Array/Accelerate/Error.hs
@@ -23,9 +23,11 @@ module Data.Array.Accelerate.Error (
 import Debug.Trace
 import Data.List                                          ( intercalate )
 import Text.Printf
-import Prelude                                            hiding ( error )
+import Prelude                                            hiding ( error, id )
 
 import GHC.Stack
+
+import Data.Array.Accelerate.Uncurrency
 
 data Check = Bounds | Unsafe | Internal
 

--- a/src/Data/Array/Accelerate/Error.hs
+++ b/src/Data/Array/Accelerate/Error.hs
@@ -33,13 +33,13 @@ data Check = Bounds | Unsafe | Internal
 -- | Issue an internal error message
 --
 internalError :: HasCallStack => String -> a
-internalError = withFrozenCallStack $ error Internal
+internalError = withFrozenCallStack `id` error Internal
 
 boundsError :: HasCallStack => String -> a
-boundsError = withFrozenCallStack $ error Bounds
+boundsError = withFrozenCallStack `id` error Bounds
 
 unsafeError :: HasCallStack => String -> a
-unsafeError = withFrozenCallStack $ error Unsafe
+unsafeError = withFrozenCallStack `id` error Unsafe
 
 
 -- | Throw an error if the condition evaluates to False, otherwise evaluate the
@@ -48,13 +48,13 @@ unsafeError = withFrozenCallStack $ error Unsafe
 --   $internalCheck :: String -> String -> Bool -> a -> a
 --
 internalCheck :: HasCallStack => String -> Bool -> a -> a
-internalCheck = withFrozenCallStack $ check Internal
+internalCheck = withFrozenCallStack `id` check Internal
 
 boundsCheck :: HasCallStack => String -> Bool -> a -> a
-boundsCheck = withFrozenCallStack $ check Bounds
+boundsCheck = withFrozenCallStack `id` check Bounds
 
 unsafeCheck :: HasCallStack => String -> Bool -> a -> a
-unsafeCheck = withFrozenCallStack $ check Unsafe
+unsafeCheck = withFrozenCallStack `id` check Unsafe
 
 
 -- | Throw an error if the index is not in range, otherwise evaluate the result.
@@ -68,13 +68,13 @@ indexCheck i n =
 --   $internalWarning :: String -> String -> Bool -> a -> a
 --
 internalWarning :: HasCallStack => String -> Bool -> a -> a
-internalWarning = withFrozenCallStack $ warning Internal
+internalWarning = withFrozenCallStack `id` warning Internal
 
 boundsWarning :: HasCallStack => String -> Bool -> a -> a
-boundsWarning = withFrozenCallStack $ warning Bounds
+boundsWarning = withFrozenCallStack `id` warning Bounds
 
 unsafeWarning :: HasCallStack => String -> Bool -> a -> a
-unsafeWarning = withFrozenCallStack $ warning Unsafe
+unsafeWarning = withFrozenCallStack `id` warning Unsafe
 
 
 error :: HasCallStack => Check -> String -> a
@@ -97,7 +97,7 @@ format kind msg = intercalate "\n" [ header, msg, ppCallStack callStack ]
   where
     header
       = intercalate "\n"
-      $ case kind of
+      `id` case kind of
           Internal -> [""
                       ,"*** Internal error in package accelerate ***"
                       ,"*** Please submit a bug report at https://github.com/AccelerateHS/accelerate/issues"

--- a/src/Data/Array/Accelerate/Lift.hs
+++ b/src/Data/Array/Accelerate/Lift.hs
@@ -61,7 +61,7 @@ lift2 :: (Unlift Exp a, Unlift Exp b, Lift Exp c)
       -> Exp (Plain a)
       -> Exp (Plain b)
       -> Exp (Plain c)
-lift2 f x y = lift $ f (unlift x) (unlift y)
+lift2 f x y = lift `id` f (unlift x) (unlift y)
 
 -- | Lift a ternary function into 'Exp'.
 --
@@ -71,7 +71,7 @@ lift3 :: (Unlift Exp a, Unlift Exp b, Unlift Exp c, Lift Exp d)
       -> Exp (Plain b)
       -> Exp (Plain c)
       -> Exp (Plain d)
-lift3 f x y z = lift $ f (unlift x) (unlift y) (unlift z)
+lift3 f x y z = lift `id` f (unlift x) (unlift y) (unlift z)
 
 -- | Lift a unary function to a computation over rank-1 indices.
 --
@@ -315,11 +315,11 @@ instance Unlift Acc () where
 
 instance (Shape sh, Elt e) => Lift Acc (Array sh e) where
   type Plain (Array sh e) = Array sh e
-  lift (Array arr) = Acc $ SmartAcc $ Use (arrayR @sh @e) arr
+  lift (Array arr) = Acc $ SmartAcc `id` Use (arrayR @sh @e) arr
 
 -- Lift and Unlift instances for tuples
 --
-runQ $ do
+runQ `id` do
     let
         mkInstances :: Name -> TypeQ -> ExpQ -> ExpQ -> ExpQ -> ExpQ -> Int -> Q [Dec]
         mkInstances con cst smart prj nil pair n = do
@@ -355,5 +355,5 @@ runQ $ do
     --
     as <- mapM mkAccInstances [2..16]
     es <- mapM mkExpInstances [2..16]
-    return $ concat (as ++ es)
+    return `id` concat (as ++ es)
 

--- a/src/Data/Array/Accelerate/Pattern.hs
+++ b/src/Data/Array/Accelerate/Pattern.hs
@@ -108,14 +108,14 @@ instance IsPattern Exp Z Z where
   matcher _ = Z
 
 instance (Elt a, Elt b) => IsPattern Exp (a :. b) (Exp a :. Exp b) where
-  builder (Exp a :. Exp b) = Exp $ SmartExp $ Pair a b
-  matcher (Exp t)          = Exp (SmartExp $ Prj PairIdxLeft t) :. Exp (SmartExp $ Prj PairIdxRight t)
+  builder (Exp a :. Exp b) = Exp $ SmartExp `id` Pair a b
+  matcher (Exp t)          = Exp (SmartExp `id` Prj PairIdxLeft t) :. Exp (SmartExp `id` Prj PairIdxRight t)
 
 
 -- IsPattern instances for up to 16-tuples (Acc and Exp). TH takes care of
 -- the (unremarkable) boilerplate for us.
 --
-runQ $ do
+runQ `id` do
     let
         -- Generate instance declarations for IsPattern of the form:
         -- instance (Arrays x, ArraysR x ~ (((), ArraysR a), ArraysR b), Arrays a, Arrays b,) => IsPattern Acc x (Acc a, Acc b)
@@ -215,7 +215,7 @@ runQ $ do
     es <- mapM mkExpPattern [0..16]
     as <- mapM mkAccPattern [0..16]
     vs <- mapM mkVecPattern [2,3,4,8,16]
-    return $ concat (es ++ as ++ vs)
+    return `id` concat (es ++ as ++ vs)
 
 
 -- | Specialised pattern synonyms for tuples, which may be more convenient to
@@ -238,7 +238,7 @@ runQ $ do
 -- > let ix = Ix 2 3    -- :: Exp DIM2
 -- > let I2 y x = ix    -- y :: Exp Int, x :: Exp Int
 --
-runQ $ do
+runQ `id` do
     let
         mkT :: Int -> Q [Dec]
         mkT n =
@@ -292,5 +292,5 @@ runQ $ do
     ts <- mapM mkT [2..16]
     is <- mapM mkI [0..9]
     vs <- mapM mkV [2,3,4,8,16]
-    return $ concat (ts ++ is ++ vs)
+    return `id` concat (ts ++ is ++ vs)
 

--- a/src/Data/Array/Accelerate/Sugar/Array.hs
+++ b/src/Data/Array/Accelerate/Sugar/Array.hs
@@ -142,19 +142,19 @@ shape (Array arr) = toElt (R.shape arr)
 -- the source and result arrays must be identical.
 --
 reshape :: forall sh sh' e. (Shape sh, Shape sh') => sh -> Array sh' e -> Array sh e
-reshape sh (Array arr) = Array $ R.reshape (shapeR @sh) (fromElt sh) (shapeR @sh') arr
+reshape sh (Array arr) = Array `id` R.reshape (shapeR @sh) (fromElt sh) (shapeR @sh') arr
 
 -- | Return the value of an array at the given multidimensional index
 --
 infixl 9 !
 (!) :: forall sh e. (Shape sh, Elt e) => Array sh e -> sh -> e
-(!) (Array arr) ix = toElt $ R.indexArray (arrayR @sh @e) arr (fromElt ix)
+(!) (Array arr) ix = toElt `id` R.indexArray (arrayR @sh @e) arr (fromElt ix)
 
 -- | Return the value of an array at given the linear (row-major) index
 --
 infixl 9 !!
 (!!) :: forall sh e. Elt e => Array sh e -> Int -> e
-(!!) (Array arr) i = toElt $ R.linearIndexArray (eltR @e) arr i
+(!!) (Array arr) i = toElt `id` R.linearIndexArray (eltR @e) arr i
 
 -- | Create an array from its representation function, applied at each
 -- index of the array
@@ -214,7 +214,7 @@ allocateArray sh = Array <$> R.allocateArray (arrayR @sh @e) (fromElt sh)
 -- thus forcing the spine of the list to be manifest on the heap.
 --
 fromList :: forall sh e. (Shape sh, Elt e) => sh -> [e] -> Array sh e
-fromList sh xs = toArr $ R.fromList (arrayR @sh @e) (fromElt sh) $ map fromElt xs
+fromList sh xs = toArr $ R.fromList (arrayR @sh @e) (fromElt sh) `id` map fromElt xs
 
 -- | Convert an accelerated 'Array' to a list in row-major order
 --
@@ -306,7 +306,7 @@ instance (Shape sh, Elt e) => Arrays (Array sh e) where
   fromArr (Array arr) = arr
   toArr               = Array
 
-runQ $ do
+runQ `id` do
   let
       mkTuple :: Int -> Q Dec
       mkTuple n =

--- a/src/Data/Array/Accelerate/Sugar/Elt.hs
+++ b/src/Data/Array/Accelerate/Sugar/Elt.hs
@@ -295,7 +295,7 @@ instance Elt Char where
   toElt   = chr . fromIntegral
   fromElt = fromIntegral . ord
 
-runQ $ do
+runQ `id` do
   let
       -- XXX: we might want to do the digItOut trick used by FromIntegral?
       --

--- a/src/Data/Array/Accelerate/Sugar/Shape.hs
+++ b/src/Data/Array/Accelerate/Sugar/Shape.hs
@@ -146,16 +146,16 @@ size = R.size (shapeR @sh) . fromElt
 -- | The empty /shape/
 --
 empty :: forall sh. Shape sh => sh
-empty = toElt $ R.empty (shapeR @sh)
+empty = toElt `id` R.empty (shapeR @sh)
 
 -- | Yield the intersection of two shapes
 intersect :: forall sh. Shape sh => sh -> sh -> sh
-intersect x y = toElt $ R.intersect (shapeR @sh) (fromElt x) (fromElt y)
+intersect x y = toElt `id` R.intersect (shapeR @sh) (fromElt x) (fromElt y)
 
 -- | Yield the union of two shapes
 --
 union :: forall sh. Shape sh => sh -> sh -> sh
-union x y = toElt $ R.union (shapeR @sh) (fromElt x) (fromElt y)
+union x y = toElt `id` R.union (shapeR @sh) (fromElt x) (fromElt y)
 
 -- | Map a multi-dimensional index into one in a linear, row-major
 -- representation of the array (first argument is the /shape/, second
@@ -198,7 +198,7 @@ iter1 sh f = R.iter1 (shapeR @sh) (fromElt sh) (f . toElt)
 -- | Convert a minpoint-maxpoint index into a zero-indexed shape
 --
 rangeToShape :: forall sh. Shape sh => (sh, sh) -> sh
-rangeToShape (u, v) = toElt $ R.rangeToShape (shapeR @sh) (fromElt u, fromElt v)
+rangeToShape (u, v) = toElt `id` R.rangeToShape (shapeR @sh) (fromElt u, fromElt v)
 
 -- | Convert a shape into a minpoint-maxpoint index
 --

--- a/src/Data/Array/Accelerate/Sugar/Stencil.hs
+++ b/src/Data/Array/Accelerate/Sugar/Stencil.hs
@@ -38,22 +38,22 @@ class Stencil sh e stencil where
 
 instance Elt e => Stencil DIM1 e (exp e, exp e, exp e) where
   type StencilR DIM1 (exp e, exp e, exp e) = EltR (e, e, e)
-  stencilR = R.StencilRunit3 $ eltR @e
+  stencilR = R.StencilRunit3 `id` eltR @e
 
 instance Elt e => Stencil DIM1 e (exp e, exp e, exp e, exp e, exp e) where
   type StencilR DIM1 (exp e, exp e, exp e, exp e, exp e) =
     EltR (e, e, e, e, e)
-  stencilR = R.StencilRunit5 $ eltR @e
+  stencilR = R.StencilRunit5 `id` eltR @e
 
 instance Elt e => Stencil DIM1 e (exp e, exp e, exp e, exp e, exp e, exp e, exp e) where
   type StencilR DIM1 (exp e, exp e, exp e, exp e, exp e, exp e, exp e) =
     EltR (e, e, e, e, e, e, e)
-  stencilR = R.StencilRunit7 $ eltR @e
+  stencilR = R.StencilRunit7 `id` eltR @e
 
 instance Elt e => Stencil DIM1 e (exp e, exp e, exp e, exp e, exp e, exp e, exp e, exp e, exp e) where
   type StencilR DIM1 (exp e, exp e, exp e, exp e, exp e, exp e, exp e, exp e, exp e) =
     EltR (e, e, e, e, e, e, e, e, e)
-  stencilR = R.StencilRunit9 $ eltR @e
+  stencilR = R.StencilRunit9 `id` eltR @e
 
 instance ( Stencil (sh:.Int) a row2
          , Stencil (sh:.Int) a row1

--- a/src/Data/Array/Accelerate/Sugar/Tag.hs
+++ b/src/Data/Array/Accelerate/Sugar/Tag.hs
@@ -70,7 +70,7 @@ instance Tagged Ordering
 instance Tagged (Maybe a)
 instance Tagged (Either a b)
 
-runQ $ do
+runQ `id` do
   let
       mkTuple :: Int -> Q Dec
       mkTuple n =

--- a/src/Data/Array/Accelerate/Uncurrency.hs
+++ b/src/Data/Array/Accelerate/Uncurrency.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE KindSignatures  #-}
+{-# LANGUAGE PolyKinds       #-}
+{-# LANGUAGE RankNTypes      #-}
+module Data.Array.Accelerate.Uncurrency (
+    id,
+) where
+
+import Prelude                                            hiding ( id )
+import GHC.Exts                                           ( TYPE )
+
+
+-- | Use in place of e.g. '($)' in order to reduce the dependency on volatile
+-- currencies.
+id :: forall r a (b :: TYPE r). (a -> b) -> a -> b
+f `id` x =  f x
+{-# INLINE id #-}
+
+infixr 0 `id`

--- a/src/Data/Atomic.hs
+++ b/src/Data/Atomic.hs
@@ -97,7 +97,7 @@ subtract = undefined
 
 -- SEE: [linking to .c files]
 --
-runQ $ do
+runQ `id` do
   addForeignFilePath LangC "cbits/atomic.c"
   return []
 

--- a/src/Data/BitSet.hs
+++ b/src/Data/BitSet.hs
@@ -129,7 +129,7 @@ foldl' f z (BitSet bits) = go z (popCount bits) 0
   where
     go !acc 0  !_ = acc
     go !acc !n !b = if bits `testBit` b
-                      then go (f acc $ toEnum b) (pred n) (succ b)
+                      then go (f acc `id` toEnum b) (pred n) (succ b)
                       else go acc n (succ b)
 
 -- | Reduce this bit set by applying a binary function to all elements,


### PR DESCRIPTION
**Description**
This pull request reduces the dependency of our codebase on dollar (`$`), by replacing it with `id`.

Dollar is actually an instantiation of the identity function, specialized to functions. Hence it makes more sense to use the more general `id`. Furthermore, `id` is an eta reduction of `$`.

I couldn't remove all uses of `$`, but this should already improve the situation a lot.

**Motivation and context**
Any instabilities of the dollar would impact Accelerate. If you for instance compare the dollar with the Venezuelan Bolivar, you'll see that dollar is actually quite unstable.

**How has this been tested?**
The nofib tests still pass.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

