### PR TITLE
Remove use of stable names from graphviz algorithm

### DIFF
--- a/src/Data/Array/Accelerate/Pretty/Graphviz/Monad.hs
+++ b/src/Data/Array/Accelerate/Pretty/Graphviz/Monad.hs
@@ -12,12 +12,9 @@
 module Data.Array.Accelerate.Pretty.Graphviz.Monad
   where
 
-import Control.Applicative
 import Control.Monad.State
 import Data.Foldable                                    ( toList )
 import Data.Sequence                                    ( Seq )
-import System.Mem.StableName
-import Prelude
 import qualified Data.Sequence                          as Seq
 import qualified Data.Text                              as Text
 
@@ -26,51 +23,52 @@ import Data.Array.Accelerate.Pretty.Graphviz.Type
 
 -- Graph construction state ----------------------------------------------------
 
-type Dot a    = StateT DotState IO a
+type Dot a    = State DotState a
 data DotState = DotState
-  { fresh       :: !Int
+  { freshLabel  :: !Int
+  , freshID     :: !Int  -- keep internal node ids in a separate counter from the user-visible node labels
   , dotGraph    :: Seq Graph
   , dotEdges    :: Seq Edge
   , dotNodes    :: Seq Node
   }
 
 emptyState :: DotState
-emptyState =  DotState 0 Seq.empty Seq.empty Seq.empty
+emptyState =  DotState 0 0 Seq.empty Seq.empty Seq.empty
 
-runDot :: Dot a -> IO (a, DotState)
-runDot dot = runStateT dot emptyState
+runDot :: Dot a -> (a, DotState)
+runDot dot = runState dot emptyState
 
-evalDot :: Dot a -> IO a
-evalDot dot = fst <$> runDot dot
+evalDot :: Dot a -> a
+evalDot dot = fst (runDot dot)
 
-execDot :: Dot a -> IO DotState
-execDot dot = snd <$> runDot dot
+execDot :: Dot a -> DotState
+execDot dot = snd (runDot dot)
 
 
 -- Utilities -------------------------------------------------------------------
 
 mkLabel :: Dot Label
 mkLabel = state $ \s ->
-  let n = fresh s
-  in  ( Text.pack ('a' : show n), s { fresh = n + 1 } )
+  let n = freshLabel s
+  in  ( Text.pack ('a' : show n), s { freshLabel = n + 1 } )
 
-mkNodeId :: a -> Dot NodeId
-mkNodeId node = do
-  sn    <- liftIO $ makeStableName node
-  return $ NodeId (hashStableName sn)
+genNodeId :: Dot NodeId
+genNodeId = state $ \s ->
+  let n = freshLabel s
+  in  ( NodeId n, s { freshID = n + 1 } )
 
 mkGraph :: Dot Graph
 mkGraph =
   state $ \DotState{..} ->
     ( Graph mempty (toList $ fmap N dotNodes Seq.>< fmap E dotEdges Seq.>< fmap G dotGraph)
-    , emptyState { fresh = fresh }
+    , emptyState { freshLabel = freshLabel }
     )
 
 mkSubgraph :: Dot Graph -> Dot Graph
 mkSubgraph g = do
-  n       <- gets fresh
-  (r, s') <- lift . runDot $ do
-    modify $ \s -> s { fresh = n }
-    g
-  state $ \s -> (r, s { fresh = fresh s' })
+  n       <- gets freshLabel
+  let (r, s') = runDot $ do
+        modify $ \s -> s { freshLabel = n }
+        g
+  state $ \s -> (r, s { freshLabel = freshLabel s' })
 


### PR DESCRIPTION
**Description**
In order to improve the stability of constructed graphs, this PR removes the usage of stable names in the graphviz dot generation algorithm.

I analysed all the use of stable names (through mkNodeId (in this commit renamed genNodeId)), and found that all usages are on objects of type:
- DelayedOpenAcc, the Manifest constructor. This is done at most once for each node in the AST.
- PreOpenAcc, only the Apair constructor. This is done at most once for each Apair in the AST.
- ALeftHandSide (when handling an Afun). At most once for each Afun.
- PNode, once on the result node of the whole program, and (in replant) once for the output graph node of AST nodes in certain positions (i.e. where replant is called).

Conclusion: makeStableName is never called twice on the same value. Hence it is useless and can be replaced by a simple id generator &mdash; which we can do trivially because the graph construction algorithm already runs in a state monad.

This removal of the usage of stable names is exactly what this PR does.

**Motivation and context**
As also noted long ago in #384, sometimes graphviz dot graphs produced by the `-ddump-dot` flag are corrupted: it has self-loops or back-edges, making it not a DAG anymore. Sometimes it is very clear in the .dot file because there are multiple different node declarations with the same id.

[An example graph before this PR](https://user-images.githubusercontent.com/6559933/116795095-bdda8180-aad2-11eb-97cb-2466ba69bfeb.png). This is a graph produced with `+ACC -fno-fusion -ddebug -ddump-dot`. My AD code was not invoked.
[Same program after this PR](https://user-images.githubusercontent.com/6559933/116795134-fbd7a580-aad2-11eb-9d1a-984b04302c3f.png), generated with the same flags.


Fixes #384.

**How has this been tested?**
My GMM code produced very corrupted graphs, especially after my AD pass but also without any AD (though there only before fusion, i.e. with `-fno-fusion`). With the fix in this PR, the produced graphs are all DAGs again.

I did not test with other programs; correctness is based only on my GMM example and my analysis as written above (and in the commit message).

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

