### PR TITLE
Change Int constraint in Shape (sh :. Int) instance for better type inference

### DIFF
--- a/src/Data/Array/Accelerate/Sugar/Shape.hs
+++ b/src/Data/Array/Accelerate/Sugar/Shape.hs
@@ -313,7 +313,12 @@ instance Shape Z where
   sliceAnyIndex  = R.SliceNil
   sliceNoneIndex = R.SliceNil
 
-instance Shape sh => Shape (sh:.Int) where
+-- Note that the constraint 'i ~ Int' allows the compiler to infer that
+-- the right argument of ':.' should be an Int.
+-- The compiler can now infer that this instance is used, before knowing
+-- the type of 'i'.
+--
+instance (Shape sh, i ~ Int) => Shape (sh:.i) where
   shapeR         = R.ShapeRsnoc (shapeR @sh)
   sliceAnyIndex  = R.SliceAll   (sliceAnyIndex  @sh)
   sliceNoneIndex = R.SliceFixed (sliceNoneIndex @sh)


### PR DESCRIPTION
Hi! Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:

**Description**
Before this change, it was often required to write a lot of type annotations to let the compiler infer the type of a shape of an array. For instance, this would give you three type errors, saying that it cannot infer the type of `10`:

```haskell
use $ fromList (Z :. 10) [0 :: Int ..]
```

This change allows the compiler to infer that the `:.` instance of `Shape` is used, before knowing the type of the right argument. However, the right argument must be an Int when used as a Shape. By changing the instance from `sh :. Int` to `sh :. i`, the compiler will use this instance and then get the constraint `i ~ Int` to infer that `i` is an Int:

```haskell
instance (Shape sh, i ~ Int) => Shape (sh:.i) where
```

**Motivation and context**
Especially when debugging with some sample inputs, you may need many type annotations on shapes. This PR prevents that (in most cases).

**How has this been tested?**
I've tested it with the mentioned example (`use $ fromList (Z :. 10) [0 :: Int ..]`).

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

