### PR TITLE
Use pattern synonyms in matrix-vector-multiplication example

### DIFF
--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -145,7 +145,7 @@ import GHC.TypeLits
 -- >       xs' = use xs
 -- >       ys' = use ys
 -- >   in
--- >   fold (+) 0 ( zipWith (*) xs' ys' )
+-- >   A.fold (+) 0 (A.zipWith (*) xs' ys')
 --
 -- The function @dotp@ consumes two one-dimensional arrays ('Vector's) of
 -- values, and produces a single ('Scalar') result as output. As the return type
@@ -177,7 +177,7 @@ import GHC.TypeLits
 -- as input (which is typically what we want):
 --
 -- > dotp :: Num a => Acc (Vector a) -> Acc (Vector a) -> Acc (Scalar a)
--- > dotp xs ys = fold (+) 0 ( zipWith (*) xs ys )
+-- > dotp xs ys = A.fold (+) 0 $ A.zipWith (*) xs ys
 --
 -- We might then be inclined to lift our dot-product program to the following
 -- (incorrect) matrix-vector product, by applying @dotp@ to each row of the
@@ -185,9 +185,9 @@ import GHC.TypeLits
 --
 -- > mvm_ndp :: Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
 -- > mvm_ndp mat vec =
--- >   let I2 rows cols  = shape mat
+-- >   let I2 rows cols = shape mat
 -- >   in  generate (I1 rows)
--- >                (\row -> the $ dotp vec (slice mat (row ::. All_)))
+-- >                (\(I1 row) -> the $ dotp vec (slice mat (I2 row All_)))
 --
 -- Here, we use 'Data.Array.Accelerate.generate' to create a one-dimensional
 -- vector by applying at each index a function to 'Data.Array.Accelerate.slice'
@@ -216,9 +216,9 @@ import GHC.TypeLits
 -- > mvm :: A.Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
 -- > mvm mat vec =
 -- >   let I2 rows cols = shape mat
--- >       vec'              = A.replicate (rows ::. All_) vec
+-- >       vec'         = A.replicate (I2 rows All_) vec
 -- >   in
--- >   A.fold (+) 0 ( A.zipWith (*) mat vec' )
+-- >   A.fold (+) 0 $ A.zipWith (*) mat vec'
 --
 -- Note that the intermediate, replicated array @vec'@ is never actually created
 -- in memory; it will be fused directly into the operation which consumes it. We

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -145,7 +145,7 @@ import GHC.TypeLits
 -- >       xs' = use xs
 -- >       ys' = use ys
 -- >   in
--- >   A.fold (+) 0 (A.zipWith (*) xs' ys')
+-- >   fold (+) 0 (zipWith (*) xs' ys')
 --
 -- The function @dotp@ consumes two one-dimensional arrays ('Vector's) of
 -- values, and produces a single ('Scalar') result as output. As the return type
@@ -177,7 +177,7 @@ import GHC.TypeLits
 -- as input (which is typically what we want):
 --
 -- > dotp :: Num a => Acc (Vector a) -> Acc (Vector a) -> Acc (Scalar a)
--- > dotp xs ys = A.fold (+) 0 $ A.zipWith (*) xs ys
+-- > dotp xs ys = fold (+) 0 $ zipWith (*) xs ys
 --
 -- We might then be inclined to lift our dot-product program to the following
 -- (incorrect) matrix-vector product, by applying @dotp@ to each row of the
@@ -213,12 +213,12 @@ import GHC.TypeLits
 -- are in the input matrix, and perform the dot-product of the vector with every
 -- row simultaneously:
 --
--- > mvm :: A.Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
+-- > mvm :: Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
 -- > mvm mat vec =
 -- >   let I2 rows cols = shape mat
--- >       vec'         = A.replicate (I2 rows All_) vec
+-- >       vec'         = replicate (I2 rows All_) vec
 -- >   in
--- >   A.fold (+) 0 $ A.zipWith (*) mat vec'
+-- >   fold (+) 0 $ zipWith (*) mat vec'
 --
 -- Note that the intermediate, replicated array @vec'@ is never actually created
 -- in memory; it will be fused directly into the operation which consumes it. We

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -185,9 +185,9 @@ import GHC.TypeLits
 --
 -- > mvm_ndp :: Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
 -- > mvm_ndp mat vec =
--- >   let Z :. rows :. cols  = unlift (shape mat)  :: Z :. Exp Int :. Exp Int
--- >   in  generate (index1 rows)
--- >                (\row -> the $ dotp vec (slice mat (lift (row :. All))))
+-- >   let I2 rows cols  = shape mat
+-- >   in  generate (I1 rows)
+-- >                (\row -> the $ dotp vec (slice mat (row ::. All_)))
 --
 -- Here, we use 'Data.Array.Accelerate.generate' to create a one-dimensional
 -- vector by applying at each index a function to 'Data.Array.Accelerate.slice'
@@ -215,8 +215,8 @@ import GHC.TypeLits
 --
 -- > mvm :: A.Num a => Acc (Matrix a) -> Acc (Vector a) -> Acc (Vector a)
 -- > mvm mat vec =
--- >   let Z :. rows :. cols = unlift (shape mat) :: Z :. Exp Int :. Exp Int
--- >       vec'              = A.replicate (lift (Z :. rows :. All)) vec
+-- >   let I2 rows cols = shape mat
+-- >       vec'              = A.replicate (rows ::. All_) vec
 -- >   in
 -- >   A.fold (+) 0 ( A.zipWith (*) mat vec' )
 --


### PR DESCRIPTION
**Description**
Use pattern synonyms instead of lift-unlift

**Motivation and context**
This example is the very first Accelerate code people see on e.g. Hackage, and the example isn't about lifting but nested parallelism. It makes sense to show the most ergonomic way to currently do this!

**How has this been tested?**
Doctest passes, but I'm not sure that it really tests this (because it also passes on the counterexample).

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Small change to start the week

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

