### PR TITLE
Fix 'drop' for negative inputs

### DIFF
--- a/src/Data/Array/Accelerate/Prelude.hs
+++ b/src/Data/Array/Accelerate/Prelude.hs
@@ -2104,7 +2104,7 @@ dropOn dim n xs =
       sh = shape xs
       m  = sh ^. dim
   in
-  backpermute (sh & dim .~ max 0 (m-n)) (& dim +~ n) xs
+  backpermute (sh & dim .~ max 0 (m - max 0 n)) (& dim +~ n) xs
 
 -- Note: [embedding constants in take & drop]
 --


### PR DESCRIPTION
**Description**
If in `drop n a` we have `n < 0`, then the current code would do an out-of-bounds array access. This trips up the backpermute.drop case in the nofib tests for accelerate-llvm-ptx.

This PR amounts to defining `drop (-1)` to be equivalent to `drop 0`. An alternative to this PR would be to modify the backpermute.drop nofib test to never pass negative counts to `drop`; this would amount to declaring `drop (-1)` to be undefined behaviour.

**Motivation and context**
I've been trying to get the accelerate-llvm-ptx test suite to work. One of the obstacles was that the backpermute.drop test case would crash with an out-of-bounds array access on the GPU device; this PR fixes that.

There are still more issues remaining with the GPU backend before its test suite can complete satisfactorily, but it's a first step.

**How has this been tested?**
The test suite for `drop` passes.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed  -- all existing tests for `drop` pass, but some of the others still fail (unrelated to this PR).

