### PR TITLE
Made some type variables existential in the Idx pattern synonyms

### DIFF
--- a/src/Data/Array/Accelerate/AST/Idx.hs
+++ b/src/Data/Array/Accelerate/AST/Idx.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell     #-}
-{-# LANGUAGE TypeApplications    #-}
 {-# LANGUAGE TypeOperators       #-}
 {-# LANGUAGE ViewPatterns        #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -77,7 +76,7 @@ newtype Idx env t = UnsafeIdxConstructor { unsafeRunIdx :: Int }
 {-# COMPLETE ZeroIdx, SuccIdx #-}
 
 pattern ZeroIdx :: forall envt t. () => forall env. (envt ~ (env, t)) => Idx envt t
-pattern ZeroIdx <- (\x -> (idxToInt x, unsafeCoerce @_ @(envt :~: (_, t)) Refl) -> (0, Refl))
+pattern ZeroIdx <- (\x -> (idxToInt x, unsafeCoerce Refl) -> (0, Refl :: envt :~: (env, t)))
   where
     ZeroIdx = UnsafeIdxConstructor 0
 

--- a/src/Data/Array/Accelerate/AST/Idx.hs
+++ b/src/Data/Array/Accelerate/AST/Idx.hs
@@ -76,12 +76,12 @@ newtype Idx env t = UnsafeIdxConstructor { unsafeRunIdx :: Int }
 
 {-# COMPLETE ZeroIdx, SuccIdx #-}
 
-pattern ZeroIdx :: forall env envt t. () => (envt ~ (env, t)) => Idx envt t
-pattern ZeroIdx <- (\x -> (idxToInt x, unsafeCoerce @(envt :~: envt) @(envt :~: (env, t)) Refl) -> (0, Refl))
+pattern ZeroIdx :: forall envt t. () => forall env. (envt ~ (env, t)) => Idx envt t
+pattern ZeroIdx <- (\x -> (idxToInt x, unsafeCoerce @_ @(envt :~: (_, t)) Refl) -> (0, Refl))
   where
     ZeroIdx = UnsafeIdxConstructor 0
 
-pattern SuccIdx :: () => (envs ~ (env, s)) => Idx env t -> Idx envs t
+pattern SuccIdx :: forall envs t. () => forall s env. (envs ~ (env, s)) => Idx env t -> Idx envs t
 pattern SuccIdx idx <- (unSucc -> Just (idx, Refl))
   where
     SuccIdx (UnsafeIdxConstructor i) = UnsafeIdxConstructor (i+1)


### PR DESCRIPTION
**Description**
Making Idx a typesafe wrapper over Ints (https://github.com/AccelerateHS/accelerate/pull/502) was good, but I've since learned more about pattern synonyms and this PR fixes a soundness issue.

**Motivation and context**
Pattern synonyms don't only have two sets of constraints (ones that are required to use the match, and ones that are provided in the body of the match): They also have two scopes of type variables (universal variables, and existential variables that are only available to the body of the match). This commit moves some type variables (e.g. the inner environment, and the type of the variable that was skipped by SuccIdx) from the universal to the existential set. The old version was unsound: Just like VoidIdx, the other synonyms allowed you to extract any type from an environment.

**How has this been tested?**
Just like in the previous PR, everything still typechecks. This version typechecks in strictly fewer programs, so it is now more difficult (impossible?) to go wrong when using the synonyms.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed (the failing Windows CI is completely unrelated)

