### PR TITLE
Fix Cabal builds and sdists after Tracy support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.ghci
 /dist/
+/dist-newstyle/
 /accelerate-examples/dist
 /accelerate-buildbot/dist
 /accelerate-cuda/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /accelerate-cuda/cubits/accelerate_cuda_shape.h
 /accelerate-io/dist/
 /.stack-work
+/cabal.project.local*
 /stack.yaml
 /stack.yaml.lock
 .DS_Store

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -587,7 +587,7 @@ test-suite doctest
   default-language:     Haskell2010
   hs-source-dirs:       test/doctest
   main-is:              Main.hs
-  other-modules:        Build_doctests
+  autogen-modules:      Build_doctests
 
   build-depends:
           base                          >= 4.10

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -147,10 +147,46 @@ extra-source-files:
     cbits/tracy/client/*.h
     cbits/tracy/client/*.hpp
     cbits/tracy/client/*.cpp
-    -- Used by the Tracy's client
+    -- These are used to build Tracy's client tools in Setup.hs
+    cbits/tracy/capture/build/unix/Makefile
+    cbits/tracy/capture/build/unix/*.mk
+    cbits/tracy/profiler/build/unix/Makefile
+    cbits/tracy/profiler/build/unix/*.mk
+    cbits/tracy/common/*.mk
+    -- The Makefiles fetch the source files from these Visual Studio project
+    -- files
+    cbits/tracy/capture/build/win32/capture.vcxproj
+    cbits/tracy/capture/build/win32/capture.vcxproj.filters
+    cbits/tracy/profiler/build/win32/Tracy.vcxproj
+    cbits/tracy/profiler/build/win32/Tracy.vcxproj.filters
+    -- Used by the Tracy's client tools
+    cbits/tracy/capture/src/*.cpp
+    cbits/tracy/imgui/*.h
+    cbits/tracy/imgui/*.cpp
+    cbits/tracy/imgui/misc/freetype/*.h
+    cbits/tracy/imgui/misc/freetype/*.cpp
     cbits/tracy/libbacktrace/*.h
     cbits/tracy/libbacktrace/*.hpp
     cbits/tracy/libbacktrace/*.cpp
+    cbits/tracy/nfd/*.h
+    cbits/tracy/nfd/*.c
+    cbits/tracy/profiler/src/*.h
+    cbits/tracy/profiler/src/*.hpp
+    cbits/tracy/profiler/src/*.cpp
+    cbits/tracy/profiler/libs/gl3w/GL/*.h
+    cbits/tracy/profiler/libs/gl3w/GL/*.c
+    cbits/tracy/server/*.h
+    cbits/tracy/server/*.hpp
+    cbits/tracy/server/*.cpp
+    cbits/tracy/zstd/*.h
+    cbits/tracy/zstd/common/*.h
+    cbits/tracy/zstd/common/*.c
+    cbits/tracy/zstd/compress/*.h
+    cbits/tracy/zstd/compress/*.c
+    cbits/tracy/zstd/decompress/*.h
+    cbits/tracy/zstd/decompress/*.c
+    cbits/tracy/zstd/dictBuilder/*.h
+    cbits/tracy/zstd/dictBuilder/*.c
 
 extra-doc-files:
     images/*.png

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -137,6 +137,7 @@ extra-source-files:
     CHANGELOG.md
     cbits/*.c
     cbits/*.h
+    -- These are referenced directly using the FFI
     cbits/tracy/*.h
     cbits/tracy/*.hpp
     cbits/tracy/*.cpp
@@ -146,6 +147,10 @@ extra-source-files:
     cbits/tracy/client/*.h
     cbits/tracy/client/*.hpp
     cbits/tracy/client/*.cpp
+    -- Used by the Tracy's client
+    cbits/tracy/libbacktrace/*.h
+    cbits/tracy/libbacktrace/*.hpp
+    cbits/tracy/libbacktrace/*.cpp
 
 extra-doc-files:
     images/*.png

--- a/src/Data/Array/Accelerate/Debug/Internal/Clock.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal/Clock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE TemplateHaskell          #-}
 {-# OPTIONS_GHC -fobject-code #-}
@@ -16,12 +17,27 @@ module Data.Array.Accelerate.Debug.Internal.Clock
 
 import Language.Haskell.TH.Syntax
 
+-- FIXME: HLS requires stubs because it does not process the
+--        'addForeignFilePath' calls when evaluating Template Haskell
+--
+--        https://github.com/haskell/haskell-language-server/issues/365
+#ifndef __GHCIDE__
+
 foreign import ccall unsafe "clock_gettime_monotonic_seconds" getMonotonicTime :: IO Double
 foreign import ccall unsafe "clock_gettime_elapsed_seconds"   getProgramTime   :: IO Double
+
+#else
+
+getMonotonicTime :: IO Double
+getMonotonicTime = undefined
+
+getProgramTime :: IO Double
+getProgramTime = undefined
+
+#endif
 
 -- SEE: [linking to .c files]
 --
 runQ $ do
   addForeignFilePath LangC "cbits/clock.c"
   return []
-

--- a/src/Data/Array/Accelerate/Debug/Internal/Profile.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal/Profile.hs
@@ -144,6 +144,12 @@ emit_remote_gc = void $ Atomic.add __num_remote_gcs 1
 -- Monitoring variables
 -- --------------------
 
+-- FIXME: HLS requires stubs because it does not process the
+--        'addForeignFilePath' calls when evaluating Template Haskell
+--
+--        https://github.com/haskell/haskell-language-server/issues/365
+#ifndef __GHCIDE__
+
 foreign import ccall "&__total_bytes_allocated_local"     __total_bytes_allocated_local     :: Atomic -- bytes allocated in the local (CPU) memory space
 foreign import ccall "&__total_bytes_allocated_remote"    __total_bytes_allocated_remote    :: Atomic -- bytes allocated in the remote memory space (if it is separate, e.g. GPU)
 foreign import ccall "&__total_bytes_copied_to_remote"    __total_bytes_copied_to_remote    :: Atomic -- bytes copied to the remote memory space
@@ -151,6 +157,31 @@ foreign import ccall "&__total_bytes_copied_from_remote"  __total_bytes_copied_f
 foreign import ccall "&__total_bytes_evicted_from_remote" __total_bytes_evicted_from_remote :: Atomic -- total bytes copied from the remote due to evictions
 foreign import ccall "&__num_remote_gcs"                  __num_remote_gcs                  :: Atomic -- number of times the remote memory space was forcibly garbage collected
 foreign import ccall "&__num_evictions"                   __num_evictions                   :: Atomic -- number of LRU eviction events
+
+#else
+
+__total_bytes_allocated_local :: Atomic
+__total_bytes_allocated_local = undefined
+
+__total_bytes_allocated_remote :: Atomic
+__total_bytes_allocated_remote = undefined
+
+__total_bytes_copied_to_remote :: Atomic
+__total_bytes_copied_to_remote = undefined
+
+__total_bytes_copied_from_remote :: Atomic
+__total_bytes_copied_from_remote = undefined
+
+__total_bytes_evicted_from_remote :: Atomic
+__total_bytes_evicted_from_remote = undefined
+
+__num_remote_gcs :: Atomic
+__num_remote_gcs = undefined
+
+__num_evictions :: Atomic
+__num_evictions = undefined
+
+#endif
 
 -- SEE: [linking to .c files]
 --

--- a/src/Data/Array/Accelerate/Debug/Internal/Tracy.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal/Tracy.hs
@@ -20,14 +20,18 @@ import Foreign.C.String
 import Foreign.C.Types
 import Foreign.Ptr
 
-#ifdef ACCELERATE_DEBUG
+#if defined(ACCELERATE_DEBUG) && !defined(__GHCIDE__)
 import Language.Haskell.TH.Syntax
 #endif
 
 type Zone   = Word64
 type SrcLoc = Word64
 
-#ifdef ACCELERATE_DEBUG
+-- FIXME: HLS requires stubs because it does not process the
+--        'addForeignFilePath' calls when evaluating Template Haskell
+--
+--        https://github.com/haskell/haskell-language-server/issues/365
+#if defined(ACCELERATE_DEBUG) && !defined(__GHCIDE__)
 
 foreign import ccall unsafe "___tracy_init_thread" init_thread :: IO ()
 foreign import ccall unsafe "___tracy_set_thread_name" set_thread_name :: CString -> IO ()


### PR DESCRIPTION
**Description**
These changes are needed so Accelerate builds with modern versions of Cabal. When building a package from version control (using the `source-repository-package` stanza in `cabal.project`), Cabal 3.4+ now creates an sdist first and then builds from that, instead of directly building from the checked out repo like Stack does. This means that source dependencies are treated exactly the same as regular Hackage packages and that built packages can be cached in the same way, but it also means that all of their source files need to be included in the sdist. Similarly, generated modules that don't exist in the source tree need to be marked as `autogen-modules` so Cabal doesn't try adding them to the tarball.

Since building an sdist doesn't involve running any code (like the `Setup.hs`, which downloads tracy if the git submodule hasn't been checked out yet) you'll need to do that first before you can create the sdist. But I don't think there's any way around that.

These changes are extracted from #510.

**Motivation and context**
It makes Accelerate work with Cabal 3.4 and later.

**How has this been tested?**
I've tested this with Cabal 3.6.2.0 by adding the following `cabal.project` file to a clone of `accelerate-llvm` and then running `cabal build -j accelerate-llvm-native`:

```cabal
packages: accelerate-llvm
          accelerate-llvm-native
          accelerate-llvm-ptx

source-repository-package
    type: git
    location: https://github.com/robbert-vdh/accelerate.git
    tag: 8628f84b89a612c4b7c237513933f5a3b2d9ac43
    -- Cabal builds from an sdist, and `accelerate.cabal` references files that
    -- don't exist on a fresh clone. The next cabal version does this
    -- automatically.
    -- XXX: For some reason cabal just stops when the command returns 0? So
    --      negating this seems to 'work'
    post-checkout-command: bash -c "! git submodule update --init --recursive"

source-repository-package
    type: git
    location: https://github.com/llvm-hs/llvm-hs.git
    tag: 351683ed1c2f6b329e62439d42a158b1d804b846
    subdir: llvm-hs llvm-hs-pure

package accelerate
    flags: +debug
```

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

