### PR TITLE
Unary Stencil

### DIFF
--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -285,11 +285,13 @@ module Data.Array.Accelerate (
   clamp, mirror, wrap, function,
 
   -- *** Common stencil patterns
-  Stencil3, Stencil5, Stencil7, Stencil9,
-  Stencil3x3, Stencil5x3, Stencil3x5, Stencil5x5,
-  Stencil3x3x3, Stencil5x3x3, Stencil3x5x3, Stencil3x3x5, Stencil5x5x3, Stencil5x3x5,
-  Stencil3x5x5, Stencil5x5x5,
-
+  Stencil1, Stencil3, Stencil5, Stencil7, Stencil9,
+  Stencil1x1, Stencil1x3, Stencil1x5, 
+  Stencil3x1, Stencil3x3, Stencil3x5, 
+  Stencil5x1, Stencil5x3, Stencil5x5,
+  Stencil3x3x3, Stencil3x5x3, Stencil3x3x5, Stencil3x5x5,
+  Stencil5x3x3, Stencil5x5x3, Stencil5x3x5, Stencil5x5x5,
+  
   -- -- ** Sequence operations
   -- collect,
 

--- a/src/Data/Array/Accelerate/Interpreter.hs
+++ b/src/Data/Array/Accelerate/Interpreter.hs
@@ -678,6 +678,14 @@ stencilAccess stencil = goR (stencilShapeR stencil) stencil
     -- dimension is Z.
     --
     goR :: ShapeR sh -> StencilR sh e stencil -> (sh -> e) -> sh -> stencil
+    goR _ (StencilRunit1 _) rf ix =
+      let
+          (z, i) = ix
+          rf' d  = rf (z, i+d)
+      in
+      ( ()
+      , rf'   0 )
+
     goR _ (StencilRunit3 _) rf ix =
       let
           (z, i) = ix
@@ -732,6 +740,13 @@ stencilAccess stencil = goR (stencilShapeR stencil) stencil
     -- when we recurse on the stencil structure we must manipulate the
     -- _left-most_ index component.
     --
+    goR (ShapeRsnoc shr) (StencilRtup1 s1) rf ix =
+      let (i, ix') = uncons shr ix
+          rf' d ds = rf (cons shr (i+d) ds)
+      in
+      ( ()
+      , goR shr s1 (rf'   0)  ix')
+      
     goR (ShapeRsnoc shr) (StencilRtup3 s1 s2 s3) rf ix =
       let (i, ix') = uncons shr ix
           rf' d ds = rf (cons shr (i+d) ds)

--- a/src/Data/Array/Accelerate/Language.hs
+++ b/src/Data/Array/Accelerate/Language.hs
@@ -97,7 +97,7 @@ module Data.Array.Accelerate.Language (
   -- * Conversions
   ord, chr, boolToInt, bitcast,
 
-) where
+Stencil1,Stencil1x3,Stencil1x5,Stencil1x1,Stencil3x1,Stencil5x1) where
 
 import Data.Array.Accelerate.AST                                    ( PrimFun(..) )
 import Data.Array.Accelerate.Pattern
@@ -851,14 +851,20 @@ backpermute = Acc $$$ applyAcc (Backpermute $ shapeR @sh')
 --
 
 -- DIM1 stencil type
+type Stencil1 a = (Exp a)
 type Stencil3 a = (Exp a, Exp a, Exp a)
 type Stencil5 a = (Exp a, Exp a, Exp a, Exp a, Exp a)
 type Stencil7 a = (Exp a, Exp a, Exp a, Exp a, Exp a, Exp a, Exp a)
 type Stencil9 a = (Exp a, Exp a, Exp a, Exp a, Exp a, Exp a, Exp a, Exp a, Exp a)
 
 -- DIM2 stencil type
+type Stencil1x1 a = (Stencil1 a)
+type Stencil3x1 a = (Stencil3 a)
+type Stencil5x1 a = (Stencil5 a)
+type Stencil1x3 a = (Stencil1 a, Stencil1 a, Stencil1 a)
 type Stencil3x3 a = (Stencil3 a, Stencil3 a, Stencil3 a)
 type Stencil5x3 a = (Stencil5 a, Stencil5 a, Stencil5 a)
+type Stencil1x5 a = (Stencil1 a, Stencil1 a, Stencil1 a, Stencil1 a, Stencil1 a)
 type Stencil3x5 a = (Stencil3 a, Stencil3 a, Stencil3 a, Stencil3 a, Stencil3 a)
 type Stencil5x5 a = (Stencil5 a, Stencil5 a, Stencil5 a, Stencil5 a, Stencil5 a)
 
@@ -908,15 +914,13 @@ type Stencil5x5x5 a = (Stencil5x5 a, Stencil5x5 a, Stencil5x5 a, Stencil5x5 a, S
 -- <https://en.wikipedia.org/wiki/Gaussian_blur Gaussian blur> as a separable
 -- 2-pass operation.
 --
--- > type Stencil5x1 a = (Stencil3 a, Stencil5 a, Stencil3 a)
--- > type Stencil1x5 a = (Stencil3 a, Stencil3 a, Stencil3 a, Stencil3 a, Stencil3 a)
 -- >
 -- > convolve5x1 :: Num a => [Exp a] -> Stencil5x1 a -> Exp a
--- > convolve5x1 kernel (_, (a,b,c,d,e), _)
+-- > convolve5x1 kernel (a,b,c,d,e)
 -- >   = Prelude.sum $ Prelude.zipWith (*) kernel [a,b,c,d,e]
 -- >
 -- > convolve1x5 :: Num a => [Exp a] -> Stencil1x5 a -> Exp a
--- > convolve1x5 kernel ((_,a,_), (_,b,_), (_,c,_), (_,d,_), (_,e,_))
+-- > convolve1x5 kernel (a,b,c,d,e)
 -- >   = Prelude.sum $ Prelude.zipWith (*) kernel [a,b,c,d,e]
 -- >
 -- > gaussian = [0.06136,0.24477,0.38774,0.24477,0.06136]

--- a/src/Data/Array/Accelerate/Representation/Type.hs
+++ b/src/Data/Array/Accelerate/Representation/Type.hs
@@ -123,5 +123,5 @@ runQ $
          in
          tySynD (mkName ("Tup" ++ show n)) (map plainTV xs) rhs
   in
-  mapM mkT [2..16]
+  mapM mkT [0..16]
 

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -625,6 +625,11 @@ class Stencil sh e stencil where
   stencilPrj :: SmartExp (StencilR sh stencil) -> stencil
 
 -- DIM1
+instance Elt e => Stencil Sugar.DIM1 e (Exp e) where
+  type StencilR Sugar.DIM1 (Exp e) = ((), EltR e)
+  stencilR = StencilRunit1 @(EltR e) $ eltR @e
+  stencilPrj s = Exp $ prj0 s
+
 instance Elt e => Stencil Sugar.DIM1 e (Exp e, Exp e, Exp e) where
   type StencilR Sugar.DIM1 (Exp e, Exp e, Exp e)
     = EltR (e, e, e)


### PR DESCRIPTION
**Description**
Adds the option to have a unary dimension in a stencil.

**Motivation and context**
Cleans up the interface a bit, and using such a unary dimension should also make the generated code faster.
There is one open question: Currently, I just use `e` as the unary stencil of 1 `e`s. Alternatively, we could use something like https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Tuple.html#t:Solo.

**How has this been tested?**
Tests pass

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

