### PR TITLE
Build with GHC 9.4.2.

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -332,7 +332,7 @@ flag nofib
 
 library
   build-depends:
-          base                          >= 4.12 && < 4.17
+          base                          >= 4.12 && < 4.18
         , ansi-terminal                 >= 0.6.2
         , base-orphans                  >= 0.3
         , bytestring                    >= 0.10.2

--- a/src/Data/Array/Accelerate/Async.hs
+++ b/src/Data/Array/Accelerate/Async.hs
@@ -91,13 +91,21 @@ cancel (Async tid _) = throwTo tid ThreadKilled
 --
 {-# INLINE rawForkIO #-}
 rawForkIO :: IO () -> IO ThreadId
+#if MIN_VERSION_ghc_prim(0,9,0)
+rawForkIO (IO action) = IO $ \s ->
+#else
 rawForkIO action = IO $ \s ->
+#endif
   case fork# action s of
     (# s', tid #) -> (# s', ThreadId tid #)
 
 {-# INLINE rawForkOn #-}
 rawForkOn :: Int -> IO () -> IO ThreadId
+#if MIN_VERSION_ghc_prim(0,9,0)
+rawForkOn (I# cpu) (IO action) = IO $ \s ->
+#else
 rawForkOn (I# cpu) action = IO $ \s ->
+#endif
   case forkOn# cpu action s of
     (# s', tid #) -> (# s', ThreadId tid #)
 


### PR DESCRIPTION


**Description**

- Bump up the upper bound of bytestring dependency
- Fixes a compatibility issue with ghc-prim-0.9.0 (along with GHC 9.4.2)
