### PR TITLE
Updated path in setup script

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -30,7 +30,7 @@ preConfHook args config_flags = do
       debugging = fromMaybe False $ lookupFlagAssignment (mkFlagName "debug") (configConfigurationsFlags config_flags)
 
   when debugging $ do
-    yes <- doesFileExist "cbits/tracy/TracyClient.cpp"
+    yes <- doesFileExist "cbits/tracy/public/TracyClient.cpp"
     if yes
       then
         -- Nix (and apparently future versions of stack) automatically update


### PR DESCRIPTION

**Description**
https://github.com/wolfpld/tracy/commit/06c7984a163388db3f8283347a246dba0328b3e2

Seems like tracy moved the checked file to the public directory.  I don't remember exactly what problem it was causing for me as it was long time ago, but still right now this check always fails, thus git submodules is run with each debug build. 

**Motivation and context**
git submodules is run with each debug build. 

**How has this been tested?**
I tested it locally with traceShow. 

**Types of changes**
Fixed the path to match submodule repo.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

