### PR TITLE
Fix mkDec function in src/Data/Array/Accelerate/Pattern/TH.hs to work with ghc version 9.8.1

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -335,7 +335,7 @@ flag nofib
 
 library
   build-depends:
-          base                          >= 4.12 && < 4.19
+          base                          >= 4.12 && < 4.20
         , ansi-terminal                 >= 0.6.2
         , base-orphans                  >= 0.3
         , bytestring                    >= 0.10.2

--- a/src/Data/Array/Accelerate/Pattern/TH.hs
+++ b/src/Data/Array/Accelerate/Pattern/TH.hs
@@ -70,9 +70,16 @@ mkPattern nm = do
 mkDec :: Dec -> DecsQ
 mkDec dec =
   case dec of
-    DataD    _ nm tv _ cs _ -> mkDataD nm tv cs
-    NewtypeD _ nm tv _ c  _ -> mkNewtypeD nm tv c
+    DataD    _ nm tv _ cs _ -> mkDataD nm (fixTVList tv) cs
+    NewtypeD _ nm tv _ c  _ -> mkNewtypeD nm (fixTVList tv) c
     _                       -> fail "mkPatterns: expected the name of a newtype or datatype"
+  
+fixTV :: TyVarBndr a -> TyVarBndr ()
+fixTV (PlainTV n _ ) = PlainTV n ()
+fixTV (KindedTV n _ k) = KindedTV n () k
+
+fixTVList :: [TyVarBndr a] -> [TyVarBndr ()]
+fixTVList list = map fixTV list
 
 mkNewtypeD :: Name -> [TyVarBndr ()] -> Con -> DecsQ
 mkNewtypeD tn tvs c = mkDataD tn tvs [c]


### PR DESCRIPTION
**Description**
The template-haskell library version 2.21.0.0 has now made TyVarBndr types contain other types. This patch removes an error during compilation caused by mkDec passing the wrong kind of TyVarBndr to mkDataD and mkNewTypeD.

**Motivation and context**
I've been trying to get accelerate-llvm-ptx to be more efficient with GPU memory, and I suspect that part of the reason it isn't is because of the Haskell runtime, so I took the time to update the accelerate library to work with the latest ghc (it still eats up all
GPU memory, but you can have this patch anyways if you want it).

**How has this been tested?**
I've tried it on a library I've been working on, and I also ran "cabal test". In both cases it seemed to work.

**Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

