### PR TITLE
Postpone requiring `Int` dimensions in IfThenElse and Stencil

### DIFF
--- a/src/Data/Array/Accelerate/Prelude.hs
+++ b/src/Data/Array/Accelerate/Prelude.hs
@@ -2213,10 +2213,10 @@ instance IfThenElse Bool a where
       True  -> t
       False -> e
 
-instance Elt a => IfThenElse (Exp Bool) (Exp a) where
+instance (Elt a, b ~ Bool) => IfThenElse (Exp b) (Exp a) where
   ifThenElse = cond
 
-instance Arrays a => IfThenElse (Exp Bool) (Acc a) where
+instance (Arrays a, b ~ Bool) => IfThenElse (Exp b) (Acc a) where
   ifThenElse = acond
 
 

--- a/src/Data/Array/Accelerate/Smart.hs
+++ b/src/Data/Array/Accelerate/Smart.hs
@@ -673,8 +673,9 @@ instance Elt e => Stencil Sugar.DIM1 e (Exp e, Exp e, Exp e, Exp e, Exp e, Exp e
 -- DIM(n+1)
 instance (Stencil (sh:.Int) a row2,
           Stencil (sh:.Int) a row1,
-          Stencil (sh:.Int) a row0) => Stencil (sh:.Int:.Int) a (row2, row1, row0) where
-  type StencilR (sh:.Int:.Int) (row2, row1, row0)
+          Stencil (sh:.Int) a row0,
+          i1 ~ Int, i2 ~ Int) => Stencil (sh:.i1:.i2) a (row2, row1, row0) where
+  type StencilR (sh:.i1:.i2) (row2, row1, row0)
     = Tup3 (StencilR (sh:.Int) row2) (StencilR (sh:.Int) row1) (StencilR (sh:.Int) row0)
   stencilR = StencilRtup3 (stencilR @(sh:.Int) @a @row2) (stencilR @(sh:.Int) @a @row1) (stencilR @(sh:.Int) @a @row0)
   stencilPrj s = (stencilPrj @(sh:.Int) @a $ prj2 s,
@@ -685,8 +686,9 @@ instance (Stencil (sh:.Int) a row4,
           Stencil (sh:.Int) a row3,
           Stencil (sh:.Int) a row2,
           Stencil (sh:.Int) a row1,
-          Stencil (sh:.Int) a row0) => Stencil (sh:.Int:.Int) a (row4, row3, row2, row1, row0) where
-  type StencilR (sh:.Int:.Int) (row4, row3, row2, row1, row0)
+          Stencil (sh:.Int) a row0,
+          i1 ~ Int, i2 ~ Int) => Stencil (sh:.i1:.i2) a (row4, row3, row2, row1, row0) where
+  type StencilR (sh:.i1:.i2) (row4, row3, row2, row1, row0)
     = Tup5 (StencilR (sh:.Int) row4) (StencilR (sh:.Int) row3) (StencilR (sh:.Int) row2)
        (StencilR (sh:.Int) row1) (StencilR (sh:.Int) row0)
   stencilR = StencilRtup5 (stencilR @(sh:.Int) @a @row4) (stencilR @(sh:.Int) @a @row3)
@@ -703,9 +705,10 @@ instance (Stencil (sh:.Int) a row6,
           Stencil (sh:.Int) a row3,
           Stencil (sh:.Int) a row2,
           Stencil (sh:.Int) a row1,
-          Stencil (sh:.Int) a row0)
-  => Stencil (sh:.Int:.Int) a (row6, row5, row4, row3, row2, row1, row0) where
-  type StencilR (sh:.Int:.Int) (row6, row5, row4, row3, row2, row1, row0)
+          Stencil (sh:.Int) a row0,
+          i1 ~ Int, i2 ~ Int)
+  => Stencil (sh:.i1:.i2) a (row6, row5, row4, row3, row2, row1, row0) where
+  type StencilR (sh:.i1:.i2) (row6, row5, row4, row3, row2, row1, row0)
     = Tup7 (StencilR (sh:.Int) row6) (StencilR (sh:.Int) row5) (StencilR (sh:.Int) row4)
        (StencilR (sh:.Int) row3) (StencilR (sh:.Int) row2) (StencilR (sh:.Int) row1)
        (StencilR (sh:.Int) row0)
@@ -728,9 +731,10 @@ instance (Stencil (sh:.Int) a row8,
           Stencil (sh:.Int) a row3,
           Stencil (sh:.Int) a row2,
           Stencil (sh:.Int) a row1,
-          Stencil (sh:.Int) a row0)
-  => Stencil (sh:.Int:.Int) a (row8, row7, row6, row5, row4, row3, row2, row1, row0) where
-  type StencilR (sh:.Int:.Int) (row8, row7, row6, row5, row4, row3, row2, row1, row0)
+          Stencil (sh:.Int) a row0,
+          i1 ~ Int, i2 ~ Int)
+  => Stencil (sh:.i1:.i2) a (row8, row7, row6, row5, row4, row3, row2, row1, row0) where
+  type StencilR (sh:.i1:.i2) (row8, row7, row6, row5, row4, row3, row2, row1, row0)
     = Tup9 (StencilR (sh:.Int) row8) (StencilR (sh:.Int) row7) (StencilR (sh:.Int) row6)
        (StencilR (sh:.Int) row5) (StencilR (sh:.Int) row4) (StencilR (sh:.Int) row3)
        (StencilR (sh:.Int) row2) (StencilR (sh:.Int) row1) (StencilR (sh:.Int) row0)


### PR DESCRIPTION
**Description**
As was done for the `Shape` type class in https://github.com/AccelerateHS/accelerate/commit/9ece31ceb23a8c078b57983b45bbebe76f6c5411, this PR modifies the `IfThenElse` and `Stencil` type classes to only require the dimensionality of the array to be known before selecting the instance. The fact that the index types for each of the dimensions is in fact `Int` is only asserted with a type-equality in the instance context (i.e. only applied _after_ the instance is selected).

**Motivation and context**
Previously, writing code like this:
```hs
foo :: Exp a -> Exp a
foo x = if x then x else x
```
would generate this error:
```
input.hs:33:9: error:
    • No instance for (IfThenElse (Exp a) (Exp a))
        arising from an if-then-else expression
    • In the expression: if x then x else x
      In an equation for ‘foo’: foo x = if x then x else x
   |
33 | foo x = if x then x else x
   |         ^^^^^^^^^^^^^^^^^^
```
which is not very helpful for the user. The updated instances will instead result in this error:
```
input.hs:33:9: error:
    • Couldn't match type ‘a’ with ‘Bool’
        arising from an if-then-else expression
      ‘a’ is a rigid type variable bound by
        the type signature for:
          foo :: forall a. Exp a -> Exp a
        at input.hs:32:1-21
    • In the expression: if x then x else x
      In an equation for ‘foo’: foo x = if x then x else x
    • Relevant bindings include
        x :: Exp a (bound at input.hs:33:5)
        foo :: Exp a -> Exp a (bound at input.hs:33:1)
   |
33 | foo x = if x then x else x
   |         ^^^^^^^^^^^^^^^^^^
```
which is somewhat more helpful.

A student ran into this. Similarly, another student ran into the Stencil case, which is also updated in this PR.

**How has this been tested?**
Tests pass.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed