### PR TITLE
Cleanup flags

### DIFF
--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -315,10 +315,11 @@ flag bounds-checks
   default:              True
   description:          Enable bounds checking in the interpreter
 
-flag unsafe-checks
-  manual:               True
-  default:              False
-  description:          Enable bounds checking in unsafe operations
+-- This flag is currently completely unused, so let's not expose it to users
+-- flag unsafe-checks
+--   manual:               True
+--   default:              False
+--   description:          Enable bounds checking in unsafe operations
 
 flag internal-checks
   manual:               True
@@ -621,9 +622,9 @@ library
     cpp-options:
         -DACCELERATE_BOUNDS_CHECKS
 
-  if flag(unsafe-checks)
-    cpp-options:
-        -DACCELERATE_UNSAFE_CHECKS
+  -- if flag(unsafe-checks)
+  --   cpp-options:
+  --       -DACCELERATE_UNSAFE_CHECKS
 
   if flag(internal-checks)
     cpp-options:

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -252,11 +252,7 @@ flag debug
     .
       * @fusion@: Enable array fusion (True).
     .
-      * @simplify@: Enable program simplification phase (True).
-    .
       * @inplace@: Enable in-place array updates (True).
-    .
-      * @flush-cache@: Clear any persistent caches on program startup (False).
     .
       * @force-recomp@: Force recompilation of array programs (False).
     .

--- a/accelerate.cabal
+++ b/accelerate.cabal
@@ -313,7 +313,7 @@ flag debug
 flag bounds-checks
   manual:               True
   default:              True
-  description:          Enable bounds checking
+  description:          Enable bounds checking in the interpreter
 
 flag unsafe-checks
   manual:               True
@@ -323,7 +323,7 @@ flag unsafe-checks
 flag internal-checks
   manual:               True
   default:              False
-  description:          Enable internal consistency checks
+  description:          Enable some internal consistency checks
 
 -- Enabling this drastically increases build times
 -- See: https://gitlab.haskell.org/ghc/ghc/issues/15751

--- a/cbits/flags.h
+++ b/cbits/flags.h
@@ -11,6 +11,8 @@
 #ifndef __ACCELERATE_FLAGS_H__
 #define __ACCELERATE_FLAGS_H__
 
+#include <stdint.h>
+
 /* NOTE: [layout of command line options bitfield]
  */
 typedef union {
@@ -21,11 +23,9 @@ typedef union {
     uint32_t acc_sharing            : 1;
     uint32_t exp_sharing            : 1;
     uint32_t fusion                 : 1;
-    uint32_t simplify               : 1;
     uint32_t inplace                : 1;
     uint32_t fast_math              : 1;
     uint32_t fast_permute_const     : 1;
-    uint32_t flush_cache            : 1;
     uint32_t force_recomp           : 1;
 
     uint32_t debug                  : 1;

--- a/src/Data/Array/Accelerate/Debug/Internal.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal.hs
@@ -18,7 +18,7 @@ module Data.Array.Accelerate.Debug.Internal (
 
   debuggingIsEnabled,
   boundsChecksAreEnabled,
-  unsafeChecksAreEnabled,
+  -- unsafeChecksAreEnabled,
   internalChecksAreEnabled,
 
   module Debug,
@@ -50,13 +50,13 @@ boundsChecksAreEnabled = True
 boundsChecksAreEnabled = False
 #endif
 
-{-# INLINE unsafeChecksAreEnabled #-}
-unsafeChecksAreEnabled :: Bool
-#ifdef ACCELERATE_UNSAFE_CHECKS
-unsafeChecksAreEnabled = True
-#else
-unsafeChecksAreEnabled = False
-#endif
+-- {-# INLINE unsafeChecksAreEnabled #-}
+-- unsafeChecksAreEnabled :: Bool
+-- #ifdef ACCELERATE_UNSAFE_CHECKS
+-- unsafeChecksAreEnabled = True
+-- #else
+-- unsafeChecksAreEnabled = False
+-- #endif
 
 {-# INLINE internalChecksAreEnabled #-}
 internalChecksAreEnabled :: Bool

--- a/src/Data/Array/Accelerate/Debug/Internal/Flags.hs
+++ b/src/Data/Array/Accelerate/Debug/Internal/Flags.hs
@@ -21,13 +21,11 @@
 module Data.Array.Accelerate.Debug.Internal.Flags (
 
   Value,
-  unfolding_use_threshold,
-  max_simplifier_iterations,
   getValue,
   setValue,
 
   Flag(..),
-  seq_sharing, acc_sharing, exp_sharing, array_fusion, simplify, inplace, flush_cache, force_recomp,
+  seq_sharing, acc_sharing, exp_sharing, array_fusion, inplace, force_recomp,
   fast_math, fast_permute_const, debug, verbose, dump_phases, dump_sharing, dump_fusion,
   dump_simpl_stats, dump_simpl_iterations, dump_vectorisation, dump_dot,
   dump_simpl_dot, dump_gc, dump_gc_stats, dump_cc, dump_ld, dump_asm, dump_exec,
@@ -63,6 +61,10 @@ newtype Value = Value (Ptr Word32)    -- see flags.c
 -- bits for other configuration options, not controlled by the command line
 -- flags.
 --
+-- However, as there are currently no such special configuration options, the
+-- bit hack complexity here is unnecessary. It's kept as an easter egg for
+-- future maintainers.
+--
 instance Enum Flag where
   toEnum            = Flag
   fromEnum (Flag x) = x
@@ -75,29 +77,27 @@ instance Show Flag where
       1  -> "acc-sharing"
       2  -> "exp-sharing"
       3  -> "fusion"
-      4  -> "simplify"
-      5  -> "inplace"
-      6  -> "fast-math"
-      7  -> "fast-permute-const"
-      8  -> "flush_cache"
-      9  -> "force-recomp"
-      10 -> "debug"
-      11 -> "verbose"
-      12 -> "dump-phases"
-      13 -> "dump-sharing"
-      14 -> "dump-fusion"
-      15 -> "dump-simpl-stats"
-      16 -> "dump-simpl-iterations"
-      17 -> "dump-vectorisation"
-      18 -> "dump-dot"
-      19 -> "dump-simpl-dot"
-      20 -> "dump-gc"
-      21 -> "dump-gc-stats"
-      22 -> "dump-cc"
-      23 -> "dump-ld"
-      24 -> "dump-asm"
-      25 -> "dump-exec"
-      26 -> "dump-sched"
+      4  -> "inplace"
+      5  -> "fast-math"
+      6  -> "fast-permute-const"
+      7  -> "force-recomp"
+      8 -> "debug"
+      9 -> "verbose"
+      10 -> "dump-phases"
+      11 -> "dump-sharing"
+      12 -> "dump-fusion"
+      13 -> "dump-simpl-stats"
+      14 -> "dump-simpl-iterations"
+      15 -> "dump-vectorisation"
+      16 -> "dump-dot"
+      17 -> "dump-simpl-dot"
+      18 -> "dump-gc"
+      19 -> "dump-gc-stats"
+      20 -> "dump-cc"
+      21 -> "dump-ld"
+      22 -> "dump-asm"
+      23 -> "dump-exec"
+      24 -> "dump-sched"
       _  -> show x
 
 -- | Conditional execution of a monadic debugging expression.
@@ -178,56 +178,44 @@ clearFlags = mapM_ clearFlag
 --
 foreign import ccall "&__cmd_line_flags" __cmd_line_flags :: Ptr Word32
 
--- These @-f<blah>=INT@ values are used by the compiler
---
-foreign import ccall "&__unfolding_use_threshold"   unfolding_use_threshold   :: Value  -- the magic cut-off figure for inlining
-foreign import ccall "&__max_simplifier_iterations" max_simplifier_iterations :: Value  -- maximum number of scalar simplification passes
-
 #else
 
 __cmd_line_flags :: Ptr Word32
 __cmd_line_flags = undefined
 
-unfolding_use_threshold :: Value
-unfolding_use_threshold = undefined
-
-max_simplifier_iterations :: Value
-max_simplifier_iterations = undefined
-
 #endif
 
 -- These @-f<blah>@ flags can be reversed with @-fno-<blah>@
 --
+-- SEE: [layout of command line options bitfield]
 seq_sharing           = Flag  0 -- recover sharing of sequence expressions
 acc_sharing           = Flag  1 -- recover sharing of array computations
 exp_sharing           = Flag  2 -- recover sharing of scalar expressions
 array_fusion          = Flag  3 -- fuse array expressions
-simplify              = Flag  4 -- simplify scalar expressions
-inplace               = Flag  5 -- allow (safe) in-place array updates
-fast_math             = Flag  6 -- use faster, less precise math library operations
-fast_permute_const    = Flag  7 -- allow non-atomic permute const for product types
-flush_cache           = Flag  8 -- delete persistent compilation cache(s)
-force_recomp          = Flag  9 -- force recompilation of array programs
+inplace               = Flag  4 -- allow (safe) in-place array updates
+fast_math             = Flag  5 -- use faster, less precise math library operations
+fast_permute_const    = Flag  6 -- allow non-atomic permute const for product types
+force_recomp          = Flag  7 -- force recompilation of array programs
 
 -- These debugging flags are disable by default and are enabled with @-d<blah>@
 --
-debug                 = Flag 10 -- compile code with debugging symbols (-g)
-verbose               = Flag 11 -- be very chatty
-dump_phases           = Flag 12 -- print information about each phase of the compiler
-dump_sharing          = Flag 13 -- sharing recovery phase
-dump_fusion           = Flag 14 -- array fusion phase
-dump_simpl_stats      = Flag 15 -- statistics form fusion/simplification
-dump_simpl_iterations = Flag 16 -- output from each simplifier iteration
-dump_vectorisation    = Flag 17 -- output from the vectoriser
-dump_dot              = Flag 18 -- generate dot output of the program
-dump_simpl_dot        = Flag 19 -- generate simplified dot output
-dump_gc               = Flag 20 -- trace garbage collector
-dump_gc_stats         = Flag 21 -- print final GC statistics
-dump_cc               = Flag 22 -- trace code generation & compilation
-dump_ld               = Flag 23 -- trace runtime linker
-dump_asm              = Flag 24 -- trace assembler
-dump_exec             = Flag 25 -- trace execution
-dump_sched            = Flag 26 -- trace scheduler
+debug                 = Flag  8 -- compile code with debugging symbols (-g)
+verbose               = Flag  9 -- be very chatty
+dump_phases           = Flag 10 -- print information about each phase of the compiler
+dump_sharing          = Flag 11 -- sharing recovery phase
+dump_fusion           = Flag 12 -- array fusion phase
+dump_simpl_stats      = Flag 13 -- statistics form fusion/simplification
+dump_simpl_iterations = Flag 14 -- output from each simplifier iteration
+dump_vectorisation    = Flag 15 -- output from the vectoriser
+dump_dot              = Flag 16 -- generate dot output of the program
+dump_simpl_dot        = Flag 17 -- generate simplified dot output
+dump_gc               = Flag 18 -- trace garbage collector
+dump_gc_stats         = Flag 19 -- print final GC statistics
+dump_cc               = Flag 20 -- trace code generation & compilation
+dump_ld               = Flag 21 -- trace runtime linker
+dump_asm              = Flag 22 -- trace assembler
+dump_exec             = Flag 23 -- trace execution
+dump_sched            = Flag 24 -- trace scheduler
 
 
 -- Note: [linking to .c files]

--- a/src/Data/Array/Accelerate/Error.hs
+++ b/src/Data/Array/Accelerate/Error.hs
@@ -128,7 +128,7 @@ ppCallStack = ppLines
 {-# INLINE doChecks #-}
 doChecks :: Check -> Bool
 doChecks Bounds   = doBoundsChecks
-doChecks Unsafe   = doUnsafeChecks
+doChecks Unsafe   = internalError "If you want to do unsafe checks, re-enable the unsafe-checks cabal flag. It is currently disabled because there are no unsafe operation checks."
 doChecks Internal = doInternalChecks
 
 doBoundsChecks :: Bool
@@ -138,12 +138,12 @@ doBoundsChecks = True
 doBoundsChecks = False
 #endif
 
-doUnsafeChecks :: Bool
-#ifdef ACCELERATE_UNSAFE_CHECKS
-doUnsafeChecks = True
-#else
-doUnsafeChecks = False
-#endif
+-- doUnsafeChecks :: Bool
+-- #ifdef ACCELERATE_UNSAFE_CHECKS
+-- doUnsafeChecks = True
+-- #else
+-- doUnsafeChecks = False
+-- #endif
 
 doInternalChecks :: Bool
 #ifdef ACCELERATE_INTERNAL_CHECKS

--- a/src/Data/Array/Accelerate/Trafo/Config.hs
+++ b/src/Data/Array/Accelerate/Trafo/Config.hs
@@ -15,12 +15,8 @@ module Data.Array.Accelerate.Trafo.Config (
   Flag(..),
   defaultOptions,
 
-  -- Other options not controlled by the command line flags
-  -- float_out_acc,
-
 ) where
 
-import Data.Bits
 import Data.BitSet
 import Data.Array.Accelerate.Debug.Internal.Flags                   as F
 
@@ -30,20 +26,12 @@ import Foreign.Storable
 
 
 data Config = Config
-  { options                   :: {-# UNPACK #-} !(BitSet Word32 Flag)
-  , unfolding_use_threshold   :: {-# UNPACK #-} !Int
-  , max_simplifier_iterations :: {-# UNPACK #-} !Int
+  { options                 :: {-# UNPACK #-} !(BitSet Word32 Flag)
   }
   deriving Show
 
 {-# NOINLINE defaultOptions #-}
 defaultOptions :: Config
 defaultOptions = unsafePerformIO $!
-  Config <$> (BitSet . (0x80000000 .|.)) <$> peek F.__cmd_line_flags
-         <*> (fromIntegral <$> F.getValue F.unfolding_use_threshold)
-         <*> (fromIntegral <$> F.getValue F.max_simplifier_iterations)
-
--- Extra options not covered by command line flags
---
--- float_out_acc          = Flag 31
+  Config <$> BitSet <$> peek F.__cmd_line_flags
 


### PR DESCRIPTION
**Description**
The cabal flags list and the `+ACC` flags list show signs of a legacy codebase. Specifically, there were some documented (and some undocumented) flags that were completely unused in both accelerate and accelerate-llvm. (Even stronger: they seem to _never_ have been used.)
This PR removes them.

**How has this been tested?**
I tested some of the options with index in the list higher than the ones I removed; they still work.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**
Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed

