### PR TITLE
Small updates to standard library

### DIFF
--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE ExplicitNamespaces  #-}
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -413,7 +414,9 @@ module Data.Array.Accelerate (
   -- ---------------------------------------------------------------------------
   -- * Useful re-exports
   (.), ($), (&), flip, error, undefined, const, id, otherwise,
+#if __GLASGOW_HASKELL__ >= 904
   type (~),
+#endif
   Show, Generic, HasCallStack,
   fromString, -- -XOverloadedStrings
   fromListN,  -- -XOverloadedLists
@@ -465,7 +468,10 @@ import qualified Data.Array.Accelerate.Sugar.Array                  as S
 import qualified Data.Array.Accelerate.Sugar.Shape                  as S
 
 import Data.Function                                                ( (&) )
-import Prelude                                                      ( (.), ($), Char, Show, flip, undefined, error, const, id, otherwise, type (~) )
+#if __GLASGOW_HASKELL__ >= 904
+import Data.Type.Equality ( type (~) )
+#endif
+import Prelude                                                      ( (.), ($), Char, Show, flip, undefined, error, const, id, otherwise )
 
 import GHC.Exts                                                     ( fromListN, fromString )
 import GHC.Generics                                                 ( Generic )

--- a/src/Data/Array/Accelerate.hs
+++ b/src/Data/Array/Accelerate.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ExplicitNamespaces  #-}
 {-# LANGUAGE PatternSynonyms     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications    #-}
@@ -411,7 +412,8 @@ module Data.Array.Accelerate (
 
   -- ---------------------------------------------------------------------------
   -- * Useful re-exports
-  (.), ($), (&), flip, error, undefined, const, otherwise,
+  (.), ($), (&), flip, error, undefined, const, id, otherwise,
+  type (~),
   Show, Generic, HasCallStack,
   fromString, -- -XOverloadedStrings
   fromListN,  -- -XOverloadedLists
@@ -463,7 +465,7 @@ import qualified Data.Array.Accelerate.Sugar.Array                  as S
 import qualified Data.Array.Accelerate.Sugar.Shape                  as S
 
 import Data.Function                                                ( (&) )
-import Prelude                                                      ( (.), ($), Char, Show, flip, undefined, error, const, otherwise )
+import Prelude                                                      ( (.), ($), Char, Show, flip, undefined, error, const, id, otherwise, type (~) )
 
 import GHC.Exts                                                     ( fromListN, fromString )
 import GHC.Generics                                                 ( Generic )

--- a/src/Data/Array/Accelerate/Classes/Eq.hs
+++ b/src/Data/Array/Accelerate/Classes/Eq.hs
@@ -119,6 +119,15 @@ instance Eq Z where
   _ == _ = True_
   _ /= _ = False_
 
+instance (Shape sh) => Eq (Any sh) where
+  _ == _ = True_
+  _ /= _ = False_
+
+instance Eq All where
+  _ == _ = True_
+  _ /= _ = False_
+
+
 -- Instances of 'Prelude.Eq' don't make sense with the standard signatures as
 -- the return type is fixed to 'Bool'. This instance is provided to provide
 -- a useful error message.

--- a/src/Data/Array/Accelerate/Classes/Eq.hs
+++ b/src/Data/Array/Accelerate/Classes/Eq.hs
@@ -203,7 +203,7 @@ runQ $ do
   ts <- mapM mkTup [2..16]
   return $ concat (concat [is,fs,ns,cs,ts])
 
-instance Eq sh => Eq (sh :. Int) where
+instance (Eq sh, Eq i) => Eq (sh :. i) where
   x == y = indexHead x == indexHead y && indexTail x == indexTail y
   x /= y = indexHead x /= indexHead y || indexTail x /= indexTail y
 

--- a/src/Data/Array/Accelerate/Control/Monad.hs
+++ b/src/Data/Array/Accelerate/Control/Monad.hs
@@ -25,6 +25,7 @@ module Data.Array.Accelerate.Control.Monad (
   -- ** Basic functions
   (=<<), (>>),
   (>=>), (<=<),
+  join,
 
   -- ** Conditional execution of monadic expressions
   when, unless,
@@ -40,7 +41,7 @@ import Data.Array.Accelerate.Language
 import Data.Array.Accelerate.Sugar.Elt
 import Data.Array.Accelerate.Smart
 
-import Prelude                                                      ( Bool, flip )
+import Prelude                                                      ( Bool, flip, id )
 
 
 -- | The 'Monad' class is used for scalar types which can be sequenced.
@@ -134,6 +135,19 @@ infixr 1 <=<
       -> (Exp a -> Exp (m c))
 (<=<) = flip (>=>)
 
+-- | The 'join' function is the conventional monad join operator. It
+-- is used to remove one level of monadic structure, projecting its
+-- bound argument into the outer level.
+--
+-- \'@'join' bss@\' can be understood as the @do@ expression
+--
+-- @
+-- do bs <- bss
+--    bs
+-- @
+--
+join :: (Monad m, Elt a, Elt (m a), Elt (m (m a))) => Exp (m (m a)) -> Exp (m a)
+join = (>>= id)
 
 -- | Conditional execution of a monadic expression
 --

--- a/src/Data/Array/Accelerate/Data/Maybe.hs
+++ b/src/Data/Array/Accelerate/Data/Maybe.hs
@@ -130,7 +130,7 @@ instance Ord a => Ord (Maybe a) where
       go Nothing_  Just_{}    = LT_
       go Just_{}   Nothing_{} = GT_
 
-instance (Monoid (Exp a), Elt a) => Monoid (Exp (Maybe a)) where
+instance (Semigroup (Exp a), Elt a) => Monoid (Exp (Maybe a)) where
   mempty = Nothing_
 
 instance (Semigroup (Exp a), Elt a) => Semigroup (Exp (Maybe a)) where


### PR DESCRIPTION
**Description**
Makes some small additions to the standard library, bringing it more in line with `base`:
- Re-export `id` (occasionally useful) and `(~)` (previously built-in syntax) from `Data.Array.Accelerate`.
- Add `join` to `Data.Array.Accelerate.Control.Monad`.
- Change the `Monoid` instance for `Maybe` to require only a `Semigroup` instance for the element, instead of `Monoid`.
- Generalize the `Eq` instance for `(sh :. i)` to support non-integer shapes. May be useful in combination with slices.
  Add `Eq` instances for `All` and `Any sh` to support this.


**How has this been tested?**
No additional tests are required. Most of these changes don't change or introduce implementations. The new `join` functions is a common utility function, with the same implementation as in `base`.

**Types of changes**
What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist**

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
